### PR TITLE
Added new test to evaluate avg interval between Vehicle Events

### DIFF
--- a/sla/apps/monitor-worker/src/analyzers/avg-interval-vehicle-events.analyzer.ts
+++ b/sla/apps/monitor-worker/src/analyzers/avg-interval-vehicle-events.analyzer.ts
@@ -1,0 +1,96 @@
+/* * */
+
+import { AnalysisData } from '@/types/analysis-data.type.js';
+import { RideAnalysis } from '@tmlmobilidade/core/types';
+import { DateTime } from 'luxon';
+
+/* * */
+
+interface ExplicitRideAnalysis extends RideAnalysis {
+	_id: 'AVG_INTERVAL_VEHICLE_EVENTS'
+	reason: 'AVG_INTERVAL_HIGHER_THAN_20_SECONDS' | 'AVG_INTERVAL_LOWER_THAN_OR_EQUAL_TO_20_SECONDS' | 'NO_VEHICLE_EVENTS_FOUND'
+	unit: 'AVG_INTERVAL_VEHICLE_EVENTS_MILLISECONDS'
+};
+
+/**
+ * This analyzer tests if the average interval between vehicle events is within limits.
+ *
+ * GRADES:
+ * → PASS = Average interval between Vehicle events is less than or equal to 20 seconds.
+ * → FAIL = Average interval between Vehicle events is higher than 20 seconds.
+ */
+export function avgIntervalVehicleEvents(analysisData: AnalysisData): ExplicitRideAnalysis {
+	try {
+		//
+
+		// 1.
+		// Return a fail grade if there are no vehicle events
+
+		if (!analysisData.vehicle_events.length) {
+			return {
+				_id: 'AVG_INTERVAL_VEHICLE_EVENTS',
+				grade: 'fail',
+				message: 'No vehicle events found.',
+				reason: 'NO_VEHICLE_EVENTS_FOUND',
+				unit: null,
+				value: null,
+			};
+		}
+
+		// 2.
+		// Evaluate each vehicle event
+
+		let totalIntervalBetweenEvents = 0;
+
+		let previousEventTimestamp = DateTime.fromJSDate(analysisData.vehicle_events[0].created_at);
+
+		for (const vehicleEvent of analysisData.vehicle_events) {
+			//
+			const vehicleTimestamp = DateTime.fromJSDate(vehicleEvent.created_at);
+			//
+			const delayInMilliseconds = vehicleTimestamp.toMillis() - previousEventTimestamp.toMillis();
+			//
+			totalIntervalBetweenEvents += delayInMilliseconds;
+			//
+			previousEventTimestamp = vehicleTimestamp;
+			//
+		}
+
+		// 3.
+		// Calculate the average interval between vehicle events
+
+		const avgIntervalBetweenEvents = totalIntervalBetweenEvents / analysisData.vehicle_events.length;
+
+		if (avgIntervalBetweenEvents <= 20000) {
+			return {
+				_id: 'AVG_INTERVAL_VEHICLE_EVENTS',
+				grade: 'pass',
+				message: 'Average interval between events is within limits.',
+				reason: 'AVG_INTERVAL_LOWER_THAN_OR_EQUAL_TO_20_SECONDS',
+				unit: 'AVG_INTERVAL_VEHICLE_EVENTS_MILLISECONDS',
+				value: avgIntervalBetweenEvents,
+			};
+		}
+
+		return {
+			_id: 'AVG_INTERVAL_VEHICLE_EVENTS',
+			grade: 'fail',
+			message: 'Average interval between events is higher than limit.',
+			reason: 'AVG_INTERVAL_HIGHER_THAN_20_SECONDS',
+			unit: 'AVG_INTERVAL_VEHICLE_EVENTS_MILLISECONDS',
+			value: avgIntervalBetweenEvents,
+		};
+
+		//
+	}
+	catch (error) {
+		return {
+			_id: 'AVG_INTERVAL_VEHICLE_EVENTS',
+			grade: 'error',
+			message: error.message,
+			reason: null,
+			unit: null,
+			value: null,
+		};
+	}
+};

--- a/sla/apps/monitor-worker/src/tasks/validate-rides.ts
+++ b/sla/apps/monitor-worker/src/tasks/validate-rides.ts
@@ -18,6 +18,7 @@ import { getObservedExtension } from '@/utils/get-observed-extension.util.js';
 
 import { atMostTwoDriverIdsAnalyzer } from '@/analyzers/at-most-two-driver-ids.analyzer.js';
 import { atMostTwoVehicleIdsAnalyzer } from '@/analyzers/at-most-two-vehicle-ids.analyzer.js';
+import { avgIntervalVehicleEvents } from '@/analyzers/avg-interval-vehicle-events.analyzer.js';
 import { excessiveVehicleEventDelayAnalyzer } from '@/analyzers/excessiveVehicleEventDelay.analyzer.js';
 import { highestVehicleEventDelayAnalyzer } from '@/analyzers/highestVehicleEventDelay.analyzer.js';
 import { lessThanTenVehicleEventsAnalyzer } from '@/analyzers/lessThanTenVehicleEvents.analyzer.js';
@@ -45,6 +46,8 @@ function runAnalyzers(analysisData: AnalysisData): RideAnalysis[] {
 		highestVehicleEventDelayAnalyzer(analysisData),
 
 		lessThanTenVehicleEventsAnalyzer(analysisData),
+
+		avgIntervalVehicleEvents(analysisData),
 
 		//
 


### PR DESCRIPTION
This pull request introduces a new analyzer to the `monitor-worker` application, which checks if the average interval between vehicle events is within specified limits. The key changes include the addition of the `avgIntervalVehicleEvents` analyzer and its integration into the ride validation process.

New analyzer addition:

* [`sla/apps/monitor-worker/src/analyzers/avg-interval-vehicle-events.analyzer.ts`](diffhunk://#diff-a42c6c036a7e85d4f7bff94e181e5218d303c3357aed3b6b5d944c2ab5d3ae3bR1-R96): Added the `avgIntervalVehicleEvents` function to analyze the average interval between vehicle events and return a pass or fail grade based on the interval.

Integration into ride validation:

* [`sla/apps/monitor-worker/src/tasks/validate-rides.ts`](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dR21): Imported the `avgIntervalVehicleEvents` analyzer and included it in the `runAnalyzers` function to ensure it is executed as part of the ride validation process. [[1]](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dR21) [[2]](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dR50-R51)