### PR TITLE
Adicionar novas propriedades ao objeto Ride

### DIFF
--- a/sla/apps/explorer-frontend/i18n/locale.ts
+++ b/sla/apps/explorer-frontend/i18n/locale.ts
@@ -11,7 +11,7 @@ const COOKIE_NAME = 'NEXT_LOCALE';
 
 /* * */
 
-export async function setUserLocale(locale) {
+export async function setUserLocale(locale: string) {
 	const cookieStore = await cookies();
 	cookieStore.set(COOKIE_NAME, locale);
 }

--- a/sla/apps/monitor-worker/src/utils/get-operational-status.util.ts
+++ b/sla/apps/monitor-worker/src/utils/get-operational-status.util.ts
@@ -1,0 +1,62 @@
+/* * */
+
+import { type Ride, type VehicleEvent } from '@tmlmobilidade/core/types';
+import { DateTime } from 'luxon';
+
+import { sortByDate } from './sort-by-date.util.js';
+
+/**
+ * This function returns the correct operational status for a given Ride, base on its scheduled_start_time and VehicleEvents data.
+ * A Ride can be considered 'scheduled', 'missed', 'running' or 'ended'.
+ * Value 'scheduled' means that the ride start time is still in the future, and no VehicleEvents were found for it.
+ * Value 'missed' means that the ride start time is at least 10 minutes ago, and no VehicleEvents were found for it.
+ * Value 'running' means that there are VehicleEvents for the ride, and the most recent one was received less than 10 minutes ago.
+ * Value 'ended' means that there are VehicleEvents for the ride, and the most recent one was received more than 10 minutes ago.
+ * @param rideData The Ride to be analyzed.
+ * @param vehicleEventsData The VehicleEvents data for the Ride.
+ * @returns The operational status for the Ride.
+ */
+export function getOperationalStatus(rideData: Ride, vehicleEventsData: VehicleEvent[]): Ride['operational_status'] {
+	//
+
+	//
+	// Check if the ride start time is in the future.
+
+	const nowInUnixSeconds = DateTime.now().toSeconds();
+	const rideStartTimeInUnixSeconds = DateTime.fromISO(String(rideData.start_time_scheduled)).toSeconds();
+
+	const secondsFromRideStartToNow = nowInUnixSeconds - rideStartTimeInUnixSeconds;
+
+	//
+	// If the ride start time is less than or equal to 10 minutes ago, or in the future,
+	// and there are no VehicleEvents for it, then the ride is considered 'scheduled'.
+
+	if (secondsFromRideStartToNow <= 600 && vehicleEventsData.length === 0) {
+		return 'scheduled';
+	}
+
+	//
+	// If the ride start time is at least 10 minutes ago, and there are no VehicleEvents for it,
+	// then the ride is considered 'missed' and no further analysis is needed.
+
+	if (secondsFromRideStartToNow > 600 && vehicleEventsData.length === 0) {
+		return 'missed';
+	}
+
+	//
+	// If there are VehicleEvents for the ride, and the most recent one was received less than or exactly at 10 minutes ago,
+	// then the ride is considered 'running'. Else it is considered 'ended'.
+
+	const mostRecentVehicleEvent = sortByDate(vehicleEventsData, 'created_at', 'desc')[0];
+	const mostRecentVehicleEventInUnixSeconds = DateTime.fromISO(String(mostRecentVehicleEvent.created_at)).toSeconds();
+
+	const secondsFromMostRecentVehicleEventToNow = nowInUnixSeconds - mostRecentVehicleEventInUnixSeconds;
+
+	if (secondsFromMostRecentVehicleEventToNow <= 600) {
+		return 'running';
+	}
+
+	return 'ended';
+
+	//
+}


### PR DESCRIPTION
This pull request includes several changes to the `sla/apps/monitor-worker` codebase, focusing on improving type safety, adding new utility functions, and updating the ride validation process.

### Ride Validation Enhancements:
* [`sla/apps/monitor-worker/src/tasks/validate-rides.ts`](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dR16): Added the `getOperationalStatus` utility function and updated the `validateRides` function to include the operational status in the ride data. [[1]](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dR16) [[2]](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dR154-R159) [[3]](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dL161-R168) [[4]](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dR202-R206) [[5]](diffhunk://#diff-e1377c0d450823cf9c3ea085581068791cea2bd5dffc4f99c55761182fe8b20dL214-R218)

### Utility Function Additions:
* [`sla/apps/monitor-worker/src/utils/get-operational-status.util.ts`](diffhunk://#diff-2ce4982ec6212cd322d86dc2f5128335fed642f258cfbd0c43784759d3500b1aR1-R62): Created a new utility function `getOperationalStatus` to determine the operational status of a ride based on its scheduled start time and vehicle events data.