### PR TITLE
Fix: API route generation to support multiple route variables

### DIFF
--- a/modules/auth/apps/frontend/src/contexts/OrganizationDetail.context.tsx
+++ b/modules/auth/apps/frontend/src/contexts/OrganizationDetail.context.tsx
@@ -222,7 +222,7 @@ export const OrganizationsDetailContextProvider = ({ children, organization_id }
 	};
 
 	const deleteImage = async (theme: 'dark' | 'light') => {
-		const themeImageRoute = API_ROUTES.auth.ORGANIZATIONS_DETAIL_(organization_id).replace('THEME_IMAGE:', '').replace(':theme', theme);
+		const themeImageRoute = API_ROUTES.auth.ORGANIZATIONS_DETAIL_VAR_IMAGE(organization_id, theme);
 		const response = await fetchData<Organization>(themeImageRoute + '?realtime=true', 'DELETE', organization);
 		if (response.error) {
 			const errors = JSON.parse(response.error);

--- a/modules/performance/apps/api/src/endpoints/metrics/metrics.routes.ts
+++ b/modules/performance/apps/api/src/endpoints/metrics/metrics.routes.ts
@@ -1,7 +1,7 @@
 /* * */
 
-import { authorizationMiddleware, FastifyService } from '@tmlmobilidade/fastify';
 import { Permissions } from '@tmlmobilidade/consts';
+import { authorizationMiddleware, FastifyService } from '@tmlmobilidade/fastify';
 import { Metric } from '@tmlmobilidade/types';
 import { FastifyInstance } from 'fastify';
 

--- a/modules/performance/apps/frontend/src/routes.ts
+++ b/modules/performance/apps/frontend/src/routes.ts
@@ -11,7 +11,7 @@ const metricEndpoint = (
 	metric: Metric['metric'],
 	queryParams?: Record<string, boolean | number | string | undefined>,
 ): string => {
-	const base = `${API_ROUTES.performance.METRICS_}/${metric}`;
+	const base = `${API_ROUTES.performance.METRICS_DETAIL(metric)}`;
 
 	if (!queryParams || Object.keys(queryParams).length === 0) return base;
 

--- a/modules/performance/environments/staging/secrets/.env.example
+++ b/modules/performance/environments/staging/secrets/.env.example
@@ -1,0 +1,7 @@
+# # # # # # # # # # # # # # # # # # #
+# WARNING - DO NOT COMMIT THIS FILE #
+# # # # # # # # # # # # # # # # # # #
+ENVIRONMENT=staging
+
+# OTHER
+DATABASE_URI=...

--- a/packages/consts/src/app-routes.ts
+++ b/packages/consts/src/app-routes.ts
@@ -162,9 +162,9 @@ export const API_ROUTES = Object.freeze({
 
 		// ORGANIZATIONS
 		ORGANIZATIONS_DETAIL: (id: string) => `${getAppConfig('auth', 'api_url')}/organizations/${id}`,
-		ORGANIZATIONS_DETAIL_: (id: string) => `${getAppConfig('auth', 'api_url')}/THEME_IMAGE:/auth/api/organizations/${id}/:theme/image`,
 		ORGANIZATIONS_DETAIL_IMAGE: (id: string) => `${getAppConfig('auth', 'api_url')}/organizations/${id}/image`,
 		ORGANIZATIONS_DETAIL_LOGO: (id: string) => `${getAppConfig('auth', 'api_url')}/organizations/${id}/logo`,
+		ORGANIZATIONS_DETAIL_VAR_IMAGE: (id: string, theme: string) => `${getAppConfig('auth', 'api_url')}/organizations/${id}/${theme}/image`,
 		ORGANIZATIONS_LIST: `${getAppConfig('auth', 'api_url')}/organizations`,
 
 		// PROPOSED-CHANGES
@@ -247,7 +247,7 @@ export const API_ROUTES = Object.freeze({
 		DATES_DATES: `${getAppConfig('performance', 'api_url')}/dates/dates`,
 
 		// METRICS
-		METRICS_: `${getAppConfig('performance', 'api_url')}/METRICNAME:/performance/api/metrics/:metricName`,
+		METRICS_DETAIL: (metricName: string) => `${getAppConfig('performance', 'api_url')}/metrics/${metricName}`,
 
 		// NETWORK
 		NETWORK_LINES: `${getAppConfig('performance', 'api_url')}/network/lines`,

--- a/scripts/generate-routes.sh
+++ b/scripts/generate-routes.sh
@@ -197,21 +197,25 @@ scan_api_routes() {
             fi
             
             # Use namespace for route path instead of endpoint_name
-            # Convert :id in namespace to ${id} for the route path
-            local namespace_for_path=$(echo "$namespace" | sed 's|:id|\${id}|g')
+            # Convert all variables (anything starting with :) in namespace to ${variable} format
+            local namespace_for_path=$(echo "$namespace" | sed -E 's|:([a-zA-Z][a-zA-Z0-9]*)|\${\1}|g')
             
             # Build the full route path by combining namespace and path
             # Remove leading slash from path if it exists
             local clean_path=$(echo "$path" | sed 's|^/||')
             
-            # Check if path is :id or starts with :id (detail route)
+            # Check if path contains any variable (anything starting with :)
             local is_detail_route=false
-            if [[ "$clean_path" == ":id" ]] || [[ "$clean_path" =~ ^:id/ ]]; then
+            if echo "$clean_path" | grep -qE '^:[a-zA-Z][a-zA-Z0-9]*'; then
                 is_detail_route=true
             fi
             
-            # Convert :id in path to ${id} for the route path
-            local clean_path_for_route=$(echo "$clean_path" | sed 's|:id|\${id}|g')
+            # Convert all variables (anything starting with :) in path to ${variable} format
+            local clean_path_for_route=$(echo "$clean_path" | sed -E 's|:([a-zA-Z][a-zA-Z0-9]*)|\${\1}|g')
+            
+            # Extract all variables from combined namespace and path for later use
+            local combined_path="${namespace}/${clean_path}"
+            local route_variables=$(echo "$combined_path" | grep -oE ':[a-zA-Z][a-zA-Z0-9]*' | sort -u | tr '\n' ' ' | sed 's/ $//')
             
             # Combine namespace and path (namespace already has leading slash removed by extraction)
             if [ "$path" = "/" ] || [ -z "$clean_path" ]; then
@@ -230,8 +234,8 @@ scan_api_routes() {
             local namespace_parts=$(echo "$namespace" | sed 's|^/||' | tr '/' ' ')
             local last_namespace_part=""
             for part in $namespace_parts; do
-                # Skip :id parts
-                if [[ "$part" != ":id" ]]; then
+                # Skip variable parts (anything starting with :)
+                if [[ ! "$part" =~ ^: ]]; then
                     last_namespace_part="$part"
                 fi
             done
@@ -243,33 +247,33 @@ scan_api_routes() {
             
             # Build route name
             if [ "$path" = "/" ] || [ -z "$clean_path" ]; then
-                # Root path - check if namespace contains :id to determine if it's a detail route
-                if [[ "$namespace" == *":id"* ]]; then
+                # Root path - check if namespace contains any variable to determine if it's a detail route
+                if echo "$namespace" | grep -qE ':[a-zA-Z][a-zA-Z0-9]*'; then
                     local route_name=$(to_snake_case "${last_namespace_part}_DETAIL")
                 else
                     local route_name=$(to_snake_case "${last_namespace_part}_LIST")
                 fi
             elif [ "$is_detail_route" = true ]; then
-                # Path is :id or starts with :id - this is a detail route
-                # Extract suffix after :id if any (e.g., /:id/image -> image)
-                local suffix_after_id=$(echo "$clean_path" | sed 's|^:id/||' | sed 's|^:id$||')
-                if [ -z "$suffix_after_id" ]; then
-                    # Just :id, so it's the detail route itself
+                # Path starts with a variable - this is a detail route
+                # Extract suffix after first variable if any (e.g., /:metricName -> empty, /:id/image -> image)
+                local suffix_after_var=$(echo "$clean_path" | sed -E 's|^:[a-zA-Z][a-zA-Z0-9]*/||' | sed -E 's|^:[a-zA-Z][a-zA-Z0-9]*$||')
+                if [ -z "$suffix_after_var" ]; then
+                    # Just a variable, so it's the detail route itself
                     local route_name=$(to_snake_case "${last_namespace_part}_DETAIL")
                 else
-                    # :id with suffix (e.g., /:id/image)
-                    local suffix_name=$(echo "$suffix_after_id" | sed 's|/|_|g' | sed 's|-|_|g')
+                    # Variable with suffix (e.g., /:id/image)
+                    local suffix_name=$(echo "$suffix_after_var" | sed 's|/|_|g' | sed 's|-|_|g' | sed -E 's|:[a-zA-Z][a-zA-Z0-9]*|VAR|g')
                     local route_name=$(to_snake_case "${last_namespace_part}_DETAIL_${suffix_name}")
                 fi
             else
-                # Non-root path without :id - use path suffix for naming
+                # Non-root path without variables - use path suffix for naming
                 local route_suffix=$(echo "$clean_path" | sed 's|/|_|g' | sed 's|-|_|g')
                 local route_name=$(to_snake_case "${last_namespace_part}_${route_suffix}")
             fi
             route_name=$(sanitize_route_name "$route_name")
             
-            # Include file name in route storage: route_name:route_path|file_name
-            routes+=("${route_name}:${route_path}|${file_name}")
+            # Include file name and variables in route storage: route_name:route_path|file_name|variables
+            routes+=("${route_name}:${route_path}|${file_name}|${route_variables}")
         done < "$grep_temp"
         
         rm -f "$grep_temp"
@@ -347,17 +351,24 @@ for module_dir in "${MODULES_DIR}"/*; do
     fi
     
     # Store routes for this module in temp file (one route per line with module prefix and type)
-    # Format: module_name|type|route_name:route_path|file_name (file_name only for API routes)
+    # Format: module_name|type|route_name:route_path|file_name|variables (variables only for API routes)
     if [ ${#module_route_list[@]} -gt 0 ]; then
         for route in "${module_route_list[@]}"; do
             if [ -n "$route" ]; then
                 # Extract route type from the route (check if it contains /api/)
                 if [[ "$route" == *"/api/"* ]]; then
                     route_type="api"
+                    # API routes have format: route_name:route_path|file_name|variables
+                    # Count pipes to ensure format is correct
+                    pipe_count=$(echo "$route" | grep -o '|' | wc -l | tr -d ' ')
+                    if [ "$pipe_count" -eq 1 ]; then
+                        # Missing variables field, add empty
+                        route="${route}|"
+                    fi
                 else
                     route_type="frontend"
-                    # For frontend routes, add empty file_name
-                    route="${route}|"
+                    # For frontend routes, add empty file_name and empty variables
+                    route="${route}||"
                 fi
                 printf '%s|%s|%s\n' "$module_name" "$route_type" "$route" >> "${MODULE_ROUTES_TEMP}"
             fi
@@ -436,11 +447,12 @@ generate_routes_for_type() {
                 continue
             fi
             
-            # Extract route_name, route_path, and file_name
+            # Extract route_name, route_path, file_name, and variables
             route_name=$(echo "$route_line" | cut -d':' -f1)
             route_path_with_file=$(echo "$route_line" | cut -d':' -f2-)
             route_path=$(echo "$route_path_with_file" | cut -d'|' -f1)
             file_name=$(echo "$route_path_with_file" | cut -d'|' -f2)
+            route_variables=$(echo "$route_path_with_file" | cut -d'|' -f3)
             
             # For API routes, use file_name for comment (convert to uppercase)
             # For frontend routes, derive comment from route name as before
@@ -472,11 +484,24 @@ generate_routes_for_type() {
                 # We want: namespace/path (without leading /module_name/api)
                 clean_api_path=$(echo "$route_path" | sed "s|^/${module_name}/api/||")
                 
-                # Check if it's a detail route (contains ${id})
-                if [[ "$route_path" == *"\${id}"* ]] || [[ "$route_path" == *'${id}'* ]]; then
+                # Check if route contains any variables
+                if [ -n "$route_variables" ]; then
+                    # Generate function parameters from variables
+                    # route_variables format: ":var1 :var2" (space-separated)
+                    function_params=""
+                    for var in $route_variables; do
+                        if [ -n "$var" ]; then
+                            # Remove leading : and use as parameter name
+                            param_name=$(echo "$var" | sed 's|^:||')
+                            if [ -z "$function_params" ]; then
+                                function_params="${param_name}: string"
+                            else
+                                function_params="${function_params}, ${param_name}: string"
+                            fi
+                        fi
+                    done
                     # Convert to function format with getAppConfig
-                    clean_path=$(echo "$clean_api_path" | sed 's|\\${id}|${id}|g' | sed "s|\${id}|\${id}|g")
-                    echo "		${route_name}: (id: string) => \`\${getAppConfig('${module_name}', 'api_url')}/${clean_path}\`," >> "$output_file"
+                    echo "		${route_name}: (${function_params}) => \`\${getAppConfig('${module_name}', 'api_url')}/${clean_api_path}\`," >> "$output_file"
                 else
                     # Regular string route with getAppConfig
                     echo "		${route_name}: \`\${getAppConfig('${module_name}', 'api_url')}/${clean_api_path}\`," >> "$output_file"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates route generator to handle multiple URL variables, refreshes generated API constants, adjusts frontend usages, and adds a staging env example.
> 
> - **Scripts**:
>   - Enhance `scripts/generate-routes.sh` to parse and emit routes with multiple `:variables` in namespaces/paths, generate function params, include variables metadata, and improve route naming for variable suffixes.
> - **Consts (generated)**:
>   - Replace placeholder endpoints with real functions: `auth.ORGANIZATIONS_DETAIL_VAR_IMAGE(id, theme)`, `performance.METRICS_DETAIL(metricName)`.
> - **Frontend**:
>   - Use `API_ROUTES.performance.METRICS_DETAIL(metric)` in `modules/performance/apps/frontend/src/routes.ts`.
>   - Use `API_ROUTES.auth.ORGANIZATIONS_DETAIL_VAR_IMAGE(id, theme)` in `modules/auth/apps/frontend/src/contexts/OrganizationDetail.context.tsx`.
> - **API**:
>   - Keep metrics routes under `namespace = '/metrics'` (minor import order tweak in `metrics.routes.ts`).
> - **Env**:
>   - Add `modules/performance/environments/staging/secrets/.env.example` with `ENVIRONMENT` and `DATABASE_URI` placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 892d61a5049a4281250a67107727238836d5d947. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->