### PR TITLE
fix: exporter app config

### DIFF
--- a/modules/exporter/apps/api/src/main.ts
+++ b/modules/exporter/apps/api/src/main.ts
@@ -24,8 +24,8 @@ const MAX_BODY_SIZE = 1024 * 1024 * 10; // 10MB
 				target: 'pino-pretty',
 			},
 		},
-		origin: getAppConfig('exports', 'cors_origin'),
-		port: getAppConfig('exports', 'api_port'),
+		origin: getAppConfig('exporter', 'cors_origin'),
+		port: getAppConfig('exporter', 'api_port'),
 		routerOptions: {
 			ignoreTrailingSlash: true,
 		},


### PR DESCRIPTION
## Problem
The exporter API used the wrong app config key (`'exports'` instead of `'exporter'`), causing:
- Runtime errors when fetching `cors_origin` and `api_port`
- Potential API startup failures
- Incorrect CORS and port configuration

### Solution
Updated `getAppConfig` calls in `modules/exporter/apps/api/src/main.ts` to use `'exporter'`, matching the key defined in `packages/consts/src/app-configs.ts`.

### Changes
- Changed `getAppConfig('exports', 'cors_origin')` → `getAppConfig('exporter', 'cors_origin')`
- Changed `getAppConfig('exports', 'api_port')` → `getAppConfig('exporter', 'api_port')`

### Impact
- Exporter API reads configuration correctly
- CORS origin configured properly
- API port configured correctly
- No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use correct app config key `'exporter'` for `cors_origin` and `api_port` in `modules/exporter/apps/api/src/main.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 644ad75851f9adb7a60637b99fb58bb5cd4c56df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->