### PR TITLE
Merge from staging

### DIFF
--- a/cli/generate-offer-files/package.json
+++ b/cli/generate-offer-files/package.json
@@ -24,12 +24,12 @@
 		"start": "tsc && resolve-tspaths && node dist/index.js"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
 		"@tmlmobilidade/consts": "*",
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/logger": "*",
 		"@tmlmobilidade/timer": "*",
 		"@tmlmobilidade/utils": "*",
+		"@tmlmobilidade/writers": "*",
 		"commander": "14.0.2",
 		"csv-parse": "6.1.0",
 		"extract-zip": "2.0.1",

--- a/cli/generate-offer-files/src/main.ts
+++ b/cli/generate-offer-files/src/main.ts
@@ -1,12 +1,12 @@
 /* * */
 
 import { type OfferJourney, type OfferStop } from '@/types.js';
-import { JsonWriter } from '@helperkits/writer';
 import { Dates, getOperationalDatesFromRange } from '@tmlmobilidade/dates';
 import { toMetersFromKilometersOrMeters } from '@tmlmobilidade/geo';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';
 import { type GTFS_Calendar_Raw, type GTFS_CalendarDate_Raw, type GTFS_Route_Extended, type GTFS_Route_Extended_Raw, type GTFS_Stop_Extended, type GTFS_Stop_Extended_Raw, type GTFS_StopTime, type GTFS_StopTime_Raw, type GTFS_Trip_Extended, type GTFS_Trip_Extended_Raw, type OperationalDate, validateGtfsCalendar, validateGtfsCalendarDate, validateGtfsRouteExtended, validateGtfsStopExtended, validateGtfsStopTime, validateGtfsTripExtended } from '@tmlmobilidade/types';
+import { JsonWriter } from '@tmlmobilidade/writers';
 import { parse as csvParser } from 'csv-parse';
 import extract from 'extract-zip';
 import fs from 'fs';

--- a/configs/sae/scripts/roles.js
+++ b/configs/sae/scripts/roles.js
@@ -23,6 +23,8 @@ db.createRole({
 		{ actions: ['find'], resource: { collection: 'plans', db: 'production' } },
 		{ actions: ['find'], resource: { collection: 'rides', db: 'production' } },
 		{ actions: ['find'], resource: { collection: 'ride_acceptances', db: 'production' } },
+		{ actions: ['find'], resource: { collection: 'hashed_shapes', db: 'production' } },
+		{ actions: ['find'], resource: { collection: 'hashed_trips', db: 'production' } },
 		{ actions: ['find', 'insert', 'update', 'remove'], resource: { collection: 'files', db: 'production' } },
 		{ actions: ['find', 'insert', 'update', 'remove'], resource: { collection: 'exports', db: 'production' } },
 	],

--- a/modules/alerts/apps/sync-datik/package.json
+++ b/modules/alerts/apps/sync-datik/package.json
@@ -18,7 +18,7 @@
 		"start": "node dist/index.js"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/logger": "*",
 		"@tmlmobilidade/timer": "*",

--- a/modules/controller/apps/frontend/src/contexts/RidesExport.context.tsx
+++ b/modules/controller/apps/frontend/src/contexts/RidesExport.context.tsx
@@ -75,6 +75,7 @@ export const RidesExportModalContextProvider = ({ children, initialFilters }: Pr
 
 		const fileName = `${Dates.fromUnixTimestamp(filterDateStart).setZone('Europe/Lisbon', 'offset_only').operational_date}_${Dates.fromUnixTimestamp(filterDateEnd).setZone('Europe/Lisbon', 'offset_only').operational_date}.csv`;
 		const createFileExportDto: CreateFileExportDto<RideExportProperties> = {
+			file_id: null,
 			file_name: fileName,
 			processing_status: 'waiting',
 			properties: {

--- a/modules/controller/apps/rides-feeder/package.json
+++ b/modules/controller/apps/rides-feeder/package.json
@@ -18,7 +18,7 @@
 		"start": "node dist/index.js"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/geo": "*",
 		"@tmlmobilidade/interfaces": "*",

--- a/modules/controller/apps/rides-feeder/src/parse-plan.ts
+++ b/modules/controller/apps/rides-feeder/src/parse-plan.ts
@@ -1,7 +1,6 @@
 /* * */
 
 import { cleanupOrphanRidesForPlan } from '@/cleanup.js';
-import { MongoDbWriter, type MongoDbWriterWriteOptions } from '@helperkits/writer';
 import { Dates, getOperationalDatesFromRange } from '@tmlmobilidade/dates';
 import { toMetersFromKilometersOrMeters } from '@tmlmobilidade/geo';
 import { files, hashedShapes, hashedTrips, plans, rides } from '@tmlmobilidade/interfaces';
@@ -9,6 +8,7 @@ import { Logger } from '@tmlmobilidade/logger';
 import { SQLiteWriter } from '@tmlmobilidade/sqlite';
 import { Timer } from '@tmlmobilidade/timer';
 import { type GTFS_Calendar_Raw, type GTFS_CalendarDate_Raw, type GTFS_Route_Extended, type GTFS_Route_Extended_Raw, type GTFS_Shape, type GTFS_Shape_Raw, type GTFS_Stop_Extended, type GTFS_Stop_Extended_Raw, type GTFS_StopTime, type GTFS_StopTime_Raw, type GTFS_Trip_Extended, type GTFS_Trip_Extended_Raw, type HashedShape, type HashedShapePoint, type HashedTrip, type HashedTripWaypoint, type OperationalDate, type Plan, type Ride, type UnixTimestamp, validateGtfsCalendar, validateGtfsCalendarDate, validateGtfsRouteExtended, validateGtfsShape, validateGtfsStopExtended, validateGtfsStopTime, validateGtfsTripExtended } from '@tmlmobilidade/types';
+import { MongoDbWriter, type MongoDbWriterWriteOptions } from '@tmlmobilidade/writers';
 import crypto from 'crypto';
 import { parse as csvParser } from 'csv-parse';
 import extract from 'extract-zip';

--- a/modules/exporter/apps/export-drt/package.json
+++ b/modules/exporter/apps/export-drt/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@carrismetropolitana/api-types": "20251114.1440.22",
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/connectors": "*",
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/interfaces": "*",

--- a/modules/exporter/apps/export-files/package.json
+++ b/modules/exporter/apps/export-files/package.json
@@ -18,7 +18,7 @@
 		"start": "node dist/index.js"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/logger": "*",
 		"@tmlmobilidade/timer": "*",

--- a/modules/exporter/apps/export-files/src/export-rides.ts
+++ b/modules/exporter/apps/export-files/src/export-rides.ts
@@ -1,11 +1,11 @@
 /* * */
 
-import { CsvWriter } from '@helperkits/writer';
 import { authProvider, fileExports, rides, ridesBatchAggregationPipeline } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { generateRandomString } from '@tmlmobilidade/strings';
 import { Timer } from '@tmlmobilidade/timer';
 import { FileExport, PermissionCatalog, RideAcceptance, RideNormalized } from '@tmlmobilidade/types';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import os from 'os';
 import path from 'path';
 

--- a/modules/exporter/apps/export-posters/package.json
+++ b/modules/exporter/apps/export-posters/package.json
@@ -17,7 +17,7 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/import-gtfs": "*",
 		"@tmlmobilidade/interfaces": "*",

--- a/modules/exporter/apps/export-posters/src/exports/agency.ts
+++ b/modules/exporter/apps/export-posters/src/exports/agency.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { type ExportToHitouchConfig } from '@/types.js';
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { Logger } from '@tmlmobilidade/logger';
 import { type Plan } from '@tmlmobilidade/types';
 

--- a/modules/exporter/apps/export-posters/src/exports/calendars.ts
+++ b/modules/exporter/apps/export-posters/src/exports/calendars.ts
@@ -3,7 +3,7 @@
 import { DAY_TYPES } from '@/day-types.js';
 import { getFormattedDates, getPeriodName, getWeekdayNames } from '@/get-names.js';
 import { type CalendarAssignmentsExt, type CalendarExt, DayTypeConfig, type ExportToHitouchConfig, type GTFS_Date } from '@/types.js';
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { type GtfsSQLTables } from '@tmlmobilidade/import-gtfs';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/exporter/apps/export-posters/src/exports/day_types.ts
+++ b/modules/exporter/apps/export-posters/src/exports/day_types.ts
@@ -2,7 +2,7 @@
 
 import { DAY_TYPES } from '@/day-types.js';
 import { DayTypesExt, type ExportToHitouchConfig } from '@/types.js';
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { Logger } from '@tmlmobilidade/logger';
 
 /* * */

--- a/modules/exporter/apps/export-posters/src/exports/feed_info.ts
+++ b/modules/exporter/apps/export-posters/src/exports/feed_info.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { type ExportToHitouchConfig } from '@/types.js';
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { Logger } from '@tmlmobilidade/logger';
 import { type Plan } from '@tmlmobilidade/types';
 

--- a/modules/exporter/apps/export-posters/src/exports/routes.ts
+++ b/modules/exporter/apps/export-posters/src/exports/routes.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { type ExportToHitouchConfig } from '@/types.js';
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { type GtfsSQLTables } from '@tmlmobilidade/import-gtfs';
 import { Logger } from '@tmlmobilidade/logger';
 import { type GTFS_Route } from '@tmlmobilidade/types';

--- a/modules/exporter/apps/export-posters/src/exports/stop-times.ts
+++ b/modules/exporter/apps/export-posters/src/exports/stop-times.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { type ExportToHitouchConfig } from '@/types.js';
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { type GtfsSQLTables } from '@tmlmobilidade/import-gtfs';
 import { Logger } from '@tmlmobilidade/logger';
 import { type GTFS_StopTime } from '@tmlmobilidade/types';

--- a/modules/exporter/apps/export-posters/src/exports/stops.ts
+++ b/modules/exporter/apps/export-posters/src/exports/stops.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { type ExportToHitouchConfig } from '@/types.js';
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { type GtfsSQLTables } from '@tmlmobilidade/import-gtfs';
 import { Logger } from '@tmlmobilidade/logger';
 import { type GTFS_Stop } from '@tmlmobilidade/types';

--- a/modules/exporter/apps/export-posters/src/exports/trips.ts
+++ b/modules/exporter/apps/export-posters/src/exports/trips.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { type ExportToHitouchConfig } from '@/types.js';
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { type GtfsSQLTables } from '@tmlmobilidade/import-gtfs';
 import { Logger } from '@tmlmobilidade/logger';
 import { type GTFS_Trip } from '@tmlmobilidade/types';

--- a/modules/replicator/apps/enrich/package.json
+++ b/modules/replicator/apps/enrich/package.json
@@ -17,7 +17,7 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/go-replicator-pckg-parse": "*",
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/logger": "*",

--- a/modules/replicator/apps/stream/package.json
+++ b/modules/replicator/apps/stream/package.json
@@ -17,7 +17,7 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/go-replicator-pckg-parse": "*",
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/logger": "*",

--- a/modules/replicator/apps/stream/src/tasks/process-apex-location.ts
+++ b/modules/replicator/apps/stream/src/tasks/process-apex-location.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseSimplifiedApexLocation } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { rides, simplifiedApexLocations } from '@tmlmobilidade/interfaces';

--- a/modules/replicator/apps/stream/src/tasks/process-apex-on-board-refund.ts
+++ b/modules/replicator/apps/stream/src/tasks/process-apex-on-board-refund.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseSimplifiedApexOnBoardRefund } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { rides, simplifiedApexOnBoardRefunds } from '@tmlmobilidade/interfaces';

--- a/modules/replicator/apps/stream/src/tasks/process-apex-on-board-sale.ts
+++ b/modules/replicator/apps/stream/src/tasks/process-apex-on-board-sale.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseSimplifiedApexOnBoardSale } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { rides, simplifiedApexOnBoardSales } from '@tmlmobilidade/interfaces';

--- a/modules/replicator/apps/stream/src/tasks/process-apex-validation.ts
+++ b/modules/replicator/apps/stream/src/tasks/process-apex-validation.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseSimplifiedApexValidation } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { rides, simplifiedApexValidations } from '@tmlmobilidade/interfaces';

--- a/modules/replicator/apps/stream/src/tasks/process-vehicle-event.ts
+++ b/modules/replicator/apps/stream/src/tasks/process-vehicle-event.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseVehicleEvent } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { rides, simplifiedVehicleEvents } from '@tmlmobilidade/interfaces';

--- a/modules/replicator/apps/sync-apex-locations/package.json
+++ b/modules/replicator/apps/sync-apex-locations/package.json
@@ -17,7 +17,7 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/go-replicator-pckg-parse": "*",
 		"@tmlmobilidade/go-replicator-pckg-sync": "*",
 		"@tmlmobilidade/interfaces": "*",

--- a/modules/replicator/apps/sync-apex-locations/src/index.ts
+++ b/modules/replicator/apps/sync-apex-locations/src/index.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseSimplifiedApexLocation } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { getEarliestDate, syncDocuments } from '@tmlmobilidade/go-replicator-pckg-sync';

--- a/modules/replicator/apps/sync-apex-on-board-refunds/package.json
+++ b/modules/replicator/apps/sync-apex-on-board-refunds/package.json
@@ -17,7 +17,7 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/go-replicator-pckg-parse": "*",
 		"@tmlmobilidade/go-replicator-pckg-sync": "*",
 		"@tmlmobilidade/interfaces": "*",

--- a/modules/replicator/apps/sync-apex-on-board-refunds/src/index.ts
+++ b/modules/replicator/apps/sync-apex-on-board-refunds/src/index.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseSimplifiedApexOnBoardRefund } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { getEarliestDate, syncDocuments } from '@tmlmobilidade/go-replicator-pckg-sync';

--- a/modules/replicator/apps/sync-apex-on-board-sales/package.json
+++ b/modules/replicator/apps/sync-apex-on-board-sales/package.json
@@ -17,7 +17,7 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/go-replicator-pckg-parse": "*",
 		"@tmlmobilidade/go-replicator-pckg-sync": "*",
 		"@tmlmobilidade/interfaces": "*",

--- a/modules/replicator/apps/sync-apex-on-board-sales/src/index.ts
+++ b/modules/replicator/apps/sync-apex-on-board-sales/src/index.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseSimplifiedApexOnBoardSale } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { getEarliestDate, syncDocuments } from '@tmlmobilidade/go-replicator-pckg-sync';

--- a/modules/replicator/apps/sync-apex-validations/package.json
+++ b/modules/replicator/apps/sync-apex-validations/package.json
@@ -17,7 +17,7 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/go-replicator-pckg-parse": "*",
 		"@tmlmobilidade/go-replicator-pckg-sync": "*",
 		"@tmlmobilidade/interfaces": "*",

--- a/modules/replicator/apps/sync-apex-validations/src/index.ts
+++ b/modules/replicator/apps/sync-apex-validations/src/index.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseSimplifiedApexValidation } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { getEarliestDate, syncDocuments } from '@tmlmobilidade/go-replicator-pckg-sync';

--- a/modules/replicator/apps/sync-vehicle-events/package.json
+++ b/modules/replicator/apps/sync-vehicle-events/package.json
@@ -17,7 +17,7 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/go-replicator-pckg-parse": "*",
 		"@tmlmobilidade/go-replicator-pckg-sync": "*",
 		"@tmlmobilidade/interfaces": "*",

--- a/modules/replicator/apps/sync-vehicle-events/src/index.ts
+++ b/modules/replicator/apps/sync-vehicle-events/src/index.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { parseVehicleEvent } from '@tmlmobilidade/go-replicator-pckg-parse';
 import { getEarliestDate, syncDocuments } from '@tmlmobilidade/go-replicator-pckg-sync';

--- a/modules/replicator/helpers/dump-data/package.json
+++ b/modules/replicator/helpers/dump-data/package.json
@@ -17,7 +17,7 @@
 		"start": "tsx watch src/index.ts"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/logger": "*",

--- a/modules/replicator/helpers/dump-data/src/from-sae-db-events.ts
+++ b/modules/replicator/helpers/dump-data/src/from-sae-db-events.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { simplifiedVehicleEvents } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/replicator/helpers/dump-data/src/from-sae-db-rides.ts
+++ b/modules/replicator/helpers/dump-data/src/from-sae-db-rides.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { rides } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';

--- a/modules/replicator/helpers/dump-data/src/from-sae-db.ts
+++ b/modules/replicator/helpers/dump-data/src/from-sae-db.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { CsvWriter } from '@helperkits/writer';
+import { CsvWriter } from '@tmlmobilidade/writers';
 import { Dates } from '@tmlmobilidade/dates';
 import { simplifiedApexValidations } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/replicator/packages/sync/package.json
+++ b/modules/replicator/packages/sync/package.json
@@ -15,7 +15,7 @@
 		"watch": "tsc-watch --onSuccess 'resolve-tspaths'"
 	},
 	"dependencies": {
-		"@helperkits/writer": "20251103.1250.18",
+		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/logger": "*",
 		"@tmlmobilidade/timer": "*"

--- a/modules/replicator/packages/sync/src/sync-documents.ts
+++ b/modules/replicator/packages/sync/src/sync-documents.ts
@@ -2,7 +2,7 @@
 
 /* * */
 
-import { type MongoDbWriter, type MongoDBWriterWriteOps } from '@helperkits/writer';
+import { type MongoDbWriter, type MongoDBWriterWriteOps } from '@tmlmobilidade/writers';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';
 

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -24,7 +24,9 @@
 		"access": "public"
 	},
 	"type": "module",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"scripts": {
@@ -37,10 +39,13 @@
 		"@fastify/cookie": "11.0.2",
 		"@fastify/cors": "11.1.0",
 		"@fastify/multipart": "9.3.0",
+		"@fastify/one-line-logger": "^2.0.2",
 		"@tmlmobilidade/consts": "*",
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/utils": "*",
-		"fastify": "5.6.2"
+		"fastify": "5.6.2",
+		"pino": "^10.1.0",
+		"pino-pretty": "^13.1.2"
 	},
 	"devDependencies": {
 		"@tmlmobilidade/tsconfig": "*",

--- a/packages/fastify/src/fastify-service.ts
+++ b/packages/fastify/src/fastify-service.ts
@@ -9,9 +9,10 @@ import '@fastify/multipart';
 import fastifyCookie from '@fastify/cookie';
 import fastifyCors from '@fastify/cors';
 import fastifyMultipart from '@fastify/multipart';
+import oneLineLogger from '@fastify/one-line-logger';
 import { HttpException, HttpStatus } from '@tmlmobilidade/consts';
 import { HttpResponse, WithPagination } from '@tmlmobilidade/utils';
-import fastify from 'fastify';
+import fastify, { FastifyLoggerOptions } from 'fastify';
 import { type FastifyInstance as FastifyInstanceType, type FastifyReply as FastifyReplyType } from 'fastify';
 import { type ContextConfigDefault, type FastifyBaseLogger, type FastifySchema, type FastifyServerOptions, type FastifyTypeProviderDefault, type RawReplyDefaultExpression, type RawRequestDefaultExpression, type RawServerBase, type RawServerDefault, type RouteGenericInterface } from 'fastify';
 
@@ -64,6 +65,78 @@ const defaultFastifyServiceOptions: FastifyServiceOptions = {
 	},
 };
 
+const loggerOptions: FastifyLoggerOptions<RawServerDefault> = {
+	level: 'debug',
+	stream: oneLineLogger({
+		colorize: true, // nice colors,
+		colorizeObjects: true,
+		messageFormat(log, messageKey, _, extras) {
+			const c = extras.colors;
+
+			const palette = {
+				highlight: c.yellowBright, // URLs / routes
+				message: c.whiteBright,
+				method: c.greenBright,
+				methodLabel: c.gray,
+				pipe: c.cyanBright,
+				reqId: c.cyanBright,
+				reqIdLabel: c.gray,
+				status: c.yellowBright,
+				statusLabel: c.gray,
+				timestamp: c.cyanBright,
+			};
+
+			const colorize = (text: string) => {
+				const urlPattern = /(https?:\/\/[^\s]+)/g;
+				const routePattern = /Route "(.+?)"/g;
+				const pathPattern = /([A-Z]+):\/[^\s]+/g;
+
+				return text
+					.replace(urlPattern, palette.highlight('$&'))
+					.replace(routePattern, (_, r) => palette.highlight(`Route "${r}"`))
+					.replace(pathPattern, palette.highlight('$&'));
+			};
+
+			const safe = (val: unknown, fallback = '') =>
+				typeof val === 'string' || typeof val === 'number' ? String(val) : fallback;
+
+			const formatMethod = (method?: string) => {
+				if (!method) return '-----';
+				if (method === 'GET' || method === 'PUT') return `${method}  `;
+				return method.padEnd(5, '-');
+			};
+
+			const timestamp = new Date(log.time as string).toLocaleString('pt-PT', {
+				day: '2-digit',
+				hour: '2-digit',
+				minute: '2-digit',
+				month: '2-digit',
+				second: '2-digit',
+				year: 'numeric',
+			});
+
+			const reqId = log.reqId ? safe(log.reqId).padEnd(10, ' ') : Array(10).fill('-').join('');
+
+			const statusCode = typeof log.res === 'object' && log.res && 'statusCode' in log.res ? safe(log.res.statusCode).padEnd(3, '-') : '---';
+
+			const method = typeof log.req === 'object' && log.req && 'method' in log.req ? formatMethod((log.req.method as string) ?? '') : '-----';
+
+			const messageRaw = safe(log[messageKey]);
+			const message = palette.message(colorize(messageRaw));
+
+			const parts = [
+				palette.timestamp(timestamp),
+				palette.reqIdLabel(`reqId: ${palette.reqId(reqId)}`),
+				palette.statusLabel(`statusCode: ${palette.status(statusCode)}`),
+				palette.methodLabel(`Method: ${palette.method(method)}`),
+				message,
+			];
+
+			return palette.pipe(parts.join(' | '));
+		},
+	}),
+};
+
 /**
  * FastifyService is a singleton class that provides a Fastify server instance.
  * It allows for setting up routes, plugins, and starting/stopping the server.
@@ -85,7 +158,7 @@ export class FastifyService {
 	 */
 	private constructor(options: FastifyServiceOptions) {
 		const mergedOptions = { ...defaultFastifyServiceOptions, ...options };
-		this.server = fastify(mergedOptions);
+		this.server = fastify({ ...mergedOptions, logger: loggerOptions });
 		this.options = mergedOptions;
 		this._setupDefaultRoutes();
 		this._setupPlugins();

--- a/packages/types/src/file-exports/common.ts
+++ b/packages/types/src/file-exports/common.ts
@@ -11,7 +11,7 @@ export type FileExportType = z.infer<typeof FileExportTypeSchema>;
 /* * */
 
 export const FileExportBaseSchema = DocumentSchema.extend({
-	file_id: z.string().nullable(),
+	file_id: z.string().nullish(),
 	file_name: z.string(),
 	processing_status: ProcessingStatusSchema,
 	properties: z.record(z.any()),
@@ -22,6 +22,7 @@ export const UpdateFileExportSchema = FileExportBaseSchema.omit({ _id: true, cre
 
 export type UpdateFileExport = z.infer<typeof UpdateFileExportSchema>;
 export type CreateFileExportDto<T extends { properties: Record<string, unknown>, type: string }> = Omit<z.infer<typeof FileExportBaseSchema>, '_id' | 'created_at' | 'file_id' | 'processing_status' | 'updated_at'> & {
+	file_id: null
 	processing_status?: 'waiting'
 	properties: T['properties']
 	type: T['type']

--- a/packages/writers/src/json.ts
+++ b/packages/writers/src/json.ts
@@ -1,7 +1,7 @@
 /* * */
 
-import LOGGER from '@helperkits/logger';
-import TIMETRACKER from '@helperkits/timer';
+import { Logger } from '@tmlmobilidade/logger';
+import { Timer } from '@tmlmobilidade/timer';
 import fs from 'node:fs';
 
 /* * */
@@ -29,7 +29,7 @@ export class JsonWriter<T> {
 
 	private MAX_BATCH_SIZE = 5000;
 
-	private SESSION_TIMER = new TIMETRACKER();
+	private SESSION_TIMER = new Timer();
 
 	/* * */
 
@@ -57,7 +57,7 @@ export class JsonWriter<T> {
 
 		if (!this.FILE_PATH) throw new Error('File path is not set. Please provide a valid file path.');
 
-		const flushTimer = new TIMETRACKER();
+		const flushTimer = new Timer();
 		const sssionTimerResult = this.SESSION_TIMER.get();
 
 		if (this.CURRENT_BATCH_DATA.length === 0) return;
@@ -83,7 +83,7 @@ export class JsonWriter<T> {
 
 		// Append the csv string to the file
 		fs.appendFileSync(this.FILE_PATH, writableData);
-		LOGGER.info(`JSONWRITER [${this.INSTANCE_NAME}]: Flush | Length: ${this.CURRENT_BATCH_DATA.length} | File Path: ${this.FILE_PATH} (session: ${sssionTimerResult}) (flush: ${flushTimer.get()})`);
+		Logger.info(`JSONWRITER [${this.INSTANCE_NAME}]: Flush | Length: ${this.CURRENT_BATCH_DATA.length} | File Path: ${this.FILE_PATH} (session: ${sssionTimerResult}) (flush: ${flushTimer.get()})`);
 		this.CURRENT_BATCH_DATA = [];
 	}
 

--- a/packages/writers/src/mongo.ts
+++ b/packages/writers/src/mongo.ts
@@ -2,8 +2,8 @@
 
 /* * */
 
-import LOGGER from '@helperkits/logger';
-import TIMETRACKER from '@helperkits/timer';
+import { Logger } from '@tmlmobilidade/logger';
+import { Timer } from '@tmlmobilidade/timer';
 
 /* * */
 
@@ -71,7 +71,7 @@ export class MongoDbWriter<T> {
 	private IDLE_TIMEOUT_TIMER: NodeJS.Timeout | null = null;
 	private IDLE_TIMEOUT_VALUE = -1;
 
-	private SESSION_TIMER = new TIMETRACKER();
+	private SESSION_TIMER = new Timer();
 
 	/* * */
 
@@ -101,7 +101,7 @@ export class MongoDbWriter<T> {
 		try {
 			//
 
-			const flushTimer = new TIMETRACKER();
+			const flushTimer = new Timer();
 			const sssionTimerResult = this.SESSION_TIMER.get();
 
 			//
@@ -159,7 +159,7 @@ export class MongoDbWriter<T> {
 
 				await this.DB_COLLECTION.bulkWrite(writeOperations);
 
-				LOGGER.info(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Flush | Length: ${this.DATA_BUCKET_FLUSH_OPS.length} (session: ${sssionTimerResult}) (flush: ${flushTimer.get()})`);
+				Logger.info(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Flush | Length: ${this.DATA_BUCKET_FLUSH_OPS.length} (session: ${sssionTimerResult}) (flush: ${flushTimer.get()})`);
 
 				//
 				// Call the flush callback, if provided
@@ -176,13 +176,13 @@ export class MongoDbWriter<T> {
 				//
 			}
 			catch (error) {
-				LOGGER.error(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Error @ flush().writeOperations(): ${error.message}`);
+				Logger.error(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Error @ flush().writeOperations(): ${error.message}`);
 			}
 
 			//
 		}
 		catch (error) {
-			LOGGER.error(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Error @ flush(): ${error.message}`);
+			Logger.error(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Error @ flush(): ${error.message}`);
 		}
 	}
 
@@ -213,7 +213,7 @@ export class MongoDbWriter<T> {
 		// Check if the batch is full
 
 		if (this.DATA_BUCKET_ALWAYS_AVAILABLE.length >= this.BATCH_SIZE) {
-			LOGGER.info(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Batch full. Flushing data...`);
+			Logger.info(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Batch full. Flushing data...`);
 			await this.flush(flushCallback);
 		}
 
@@ -248,7 +248,7 @@ export class MongoDbWriter<T> {
 
 		if (this.IDLE_TIMEOUT_ENABLED && !this.IDLE_TIMEOUT_TIMER) {
 			this.IDLE_TIMEOUT_TIMER = setTimeout(async () => {
-				LOGGER.info(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Idle timeout reached. Flushing data...`);
+				Logger.info(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Idle timeout reached. Flushing data...`);
 				await this.flush(flushCallback);
 			}, this.IDLE_TIMEOUT_VALUE);
 		}
@@ -259,7 +259,7 @@ export class MongoDbWriter<T> {
 
 		if (this.BATCH_TIMEOUT_ENABLED && !this.BATCH_TIMEOUT_TIMER) {
 			this.BATCH_TIMEOUT_TIMER = setTimeout(async () => {
-				LOGGER.info(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Batch timeout reached. Flushing data...`);
+				Logger.info(`MONGODBWRITER [${this.DB_COLLECTION.collectionName}]: Batch timeout reached. Flushing data...`);
 				await this.flush(flushCallback);
 			}, this.BATCH_TIMEOUT_VALUE);
 		}

--- a/packages/writers/src/postgres.ts
+++ b/packages/writers/src/postgres.ts
@@ -1,7 +1,7 @@
 /* * */
 
-import LOGGER from '@helperkits/logger';
-import TIMETRACKER from '@helperkits/timer';
+import { Logger } from '@tmlmobilidade/logger';
+import { Timer } from '@tmlmobilidade/timer';
 
 /* * */
 
@@ -24,7 +24,7 @@ export class PostgresWriter {
 
 	private MAX_BATCH_SIZE = 250;
 
-	private SESSION_TIMER = new TIMETRACKER();
+	private SESSION_TIMER = new Timer();
 
 	/* * */
 
@@ -41,7 +41,7 @@ export class PostgresWriter {
 		try {
 			//
 
-			const flushTimer = new TIMETRACKER();
+			const flushTimer = new Timer();
 			const sssionTimerResult = this.SESSION_TIMER.get();
 
 			if (this.CURRENT_BATCH_DATA.length === 0) return;
@@ -67,14 +67,14 @@ export class PostgresWriter {
 
 			await this.DB_CLIENT.query(insertQuery, values);
 
-			LOGGER.info(`POSTGRESWRITER [${this.INSTANCE_NAME}]: Flush | Length: ${this.CURRENT_BATCH_DATA.length} | DB Table: ${this.DB_TABLE} (session: ${sssionTimerResult}) (flush: ${flushTimer.get()})`);
+			Logger.info(`POSTGRESWRITER [${this.INSTANCE_NAME}]: Flush | Length: ${this.CURRENT_BATCH_DATA.length} | DB Table: ${this.DB_TABLE} (session: ${sssionTimerResult}) (flush: ${flushTimer.get()})`);
 
 			this.CURRENT_BATCH_DATA = [];
 
 			//
 		}
 		catch (error) {
-			LOGGER.error(`POSTGRESWRITER [${this.INSTANCE_NAME}]: Error @ flush(): ${error.message}`);
+			Logger.error(`POSTGRESWRITER [${this.INSTANCE_NAME}]: Error @ flush(): ${error.message}`);
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces @helperkits/writer with @tmlmobilidade/writers across the codebase, enhances Fastify logging, adjusts file export types/usage, and grants exporter read access to hashed_* collections.
> 
> - **Core libraries**:
>   - Migrate all apps/packages from `@helperkits/writer` to `@tmlmobilidade/writers` (JSON/CSV/Mongo/Postgres writers).
>   - Update writers to use `@tmlmobilidade/logger` and `@tmlmobilidade/timer`.
> - **API/Server (Fastify)**:
>   - Add `@fastify/one-line-logger` with custom formatter; instantiate Fastify with `loggerOptions`.
>   - Add logging deps (`pino`, `pino-pretty`) and minor `package.json` tweaks.
> - **Exports**:
>   - Update `packages/types` `FileExportBaseSchema`: `file_id` becomes `nullish`; `CreateFileExportDto` now sets `file_id: null` and optional `processing_status`.
>   - Frontend (`RidesExport.context`) sends `file_id: null` when creating exports.
>   - `export-files` ride CSV export uses `CsvWriter` from new writers.
> - **Permissions**:
>   - Mongo `exporter` role: add `find` on `production.hashed_shapes` and `production.hashed_trips`.
> - **CLI/Controllers/Replicator/Exporter**:
>   - Update imports/usages to new writers in `generate-offer-files`, rides-feeder, poster exports, replicator stream/sync helpers/packages (no functional changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78ed44d0c8e06ee7aaa0c65775dd8705d751e92f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->