### PR TITLE
fix: fastify multipart

### DIFF
--- a/modules/exporter/apps/export-gtfs-merged/src/exports/stop-times.ts
+++ b/modules/exporter/apps/export-gtfs-merged/src/exports/stop-times.ts
@@ -33,7 +33,7 @@ export async function exportStopTimesRows(planData: Plan, sqlTables: GtfsSQLTabl
 			trip_id: `${planData._id}/${stopTimeData.trip_id}`,
 			arrival_time: stopTimeData.arrival_time,
 			departure_time: stopTimeData.departure_time,
-			stop_id: `${planData._id}/${stopTimeData.stop_id}`,
+			stop_id: stopTimeData.stop_id,
 			stop_sequence: stopTimeData.stop_sequence,
 			pickup_type: stopTimeData.pickup_type ?? 0,
 			drop_off_type: stopTimeData.drop_off_type ?? 0,

--- a/modules/exporter/apps/export-gtfs-merged/src/main.ts
+++ b/modules/exporter/apps/export-gtfs-merged/src/main.ts
@@ -69,7 +69,7 @@ export async function main() {
 	let farthestDateFound: OperationalDate;
 
 	const referencedAgencyIds = new Set<string>();
-	const routesMarkedForFinalExport = new Map<string, GTFS_Route_Extended>();
+	const routesMarkedForFinalExport: Record<string, GTFS_Route_Extended> = {};
 
 	//
 	// Get all plans that are active and upcoming.
@@ -179,8 +179,8 @@ export async function main() {
 
 		for await (const routeItem of importedGtfsSql.routes.stream()) {
 			const routeData: GTFS_Route_Extended = routeItem;
-			if (thisIsAnActivePlan || !routesMarkedForFinalExport.has(routeData.route_id)) {
-				routesMarkedForFinalExport.set(routeData.route_id, routeData);
+			if (thisIsAnActivePlan || !routesMarkedForFinalExport[routeData.route_id]) {
+				routesMarkedForFinalExport[routeData.route_id] = routeData;
 			}
 		}
 

--- a/modules/locations/apps/frontend/src/app/layout.tsx
+++ b/modules/locations/apps/frontend/src/app/layout.tsx
@@ -2,7 +2,7 @@
 
 import { MapOptionsContextProvider } from '@/components/map/MapOptions.context';
 import { getAppConfig } from '@tmlmobilidade/consts';
-import { ThemeContextProvider } from '@tmlmobilidade/ui';
+import { LayoutContextProvider } from '@tmlmobilidade/ui';
 import { Metadata } from 'next';
 import { cookies as nextCookies } from 'next/headers';
 import { redirect, RedirectType } from 'next/navigation';
@@ -38,11 +38,11 @@ export default async function Layout({ children }: PropsWithChildren) {
 	return (
 		<html lang="en" suppressHydrationWarning>
 			<body>
-				<ThemeContextProvider>
+				<LayoutContextProvider>
 					<MapOptionsContextProvider>
 						{children}
 					</MapOptionsContextProvider>
-				</ThemeContextProvider>
+				</LayoutContextProvider>
 			</body>
 		</html>
 	);

--- a/modules/plans/apps/api/src/main.ts
+++ b/modules/plans/apps/api/src/main.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import fastifyMultipart from '@fastify/multipart';
 import { getAppConfig } from '@tmlmobilidade/consts';
 import { FastifyService } from '@tmlmobilidade/fastify';
 
@@ -12,6 +13,10 @@ import { FastifyService } from '@tmlmobilidade/fastify';
 		bodyLimit: 1024 * 1024 * 1024 * 2, // 2GB
 		origin: getAppConfig('plans', 'cors_origin'),
 		port: getAppConfig('plans', 'api_port'),
+	});
+
+	await fastifyService.server.register(fastifyMultipart, {
+		limits: { fileSize: 1024 * 1024 * 1024 * 2 },
 	});
 
 	await fastifyService.start();

--- a/packages/fastify/src/fastify-service.ts
+++ b/packages/fastify/src/fastify-service.ts
@@ -295,9 +295,9 @@ export class FastifyService {
 		// Cookie plugin
 		await this.server.register(fastifyCookie);
 		// Multipart plugin
-		await this.server.register(fastifyMultipart, {
-			limits: { fileSize: this.options.bodyLimit },
-		});
+		// await this.server.register(fastifyMultipart, {
+		// 	limits: { fileSize: this.options.bodyLimit },
+		// });
 	}
 
 	//

--- a/packages/ui/src/components/topbar/TopbarOptions/index.tsx
+++ b/packages/ui/src/components/topbar/TopbarOptions/index.tsx
@@ -7,7 +7,7 @@ import { IconBellRinging, IconBrightness, IconCheck, IconColorSwatch, IconLogout
 
 import { useMeContext } from '../../../contexts/Me.context';
 import { useNotificationsContext } from '../../../contexts/Notifications.context';
-import { AVAILABLE_MODES, AVAILABLE_THEMES, useThemeContext } from '../../../contexts/Theme.context';
+import { AVAILABLE_MODES, AVAILABLE_THEMES, useLayoutContext } from '../../../contexts/Layout.context';
 import { TopbarMenu } from '../TopbarMenu';
 
 /* * */
@@ -19,7 +19,7 @@ export function TopbarOptions() {
 	// A. Setup variables
 
 	const meContext = useMeContext();
-	const themeContext = useThemeContext();
+	const layoutContext = useLayoutContext();
 	const notificationsContext = useNotificationsContext();
 
 	//
@@ -41,8 +41,8 @@ export function TopbarOptions() {
 						<Menu.Item
 							key={item._id}
 							leftSection={item.icon}
-							onClick={() => themeContext.actions.activateMode(item._id)}
-							rightSection={themeContext.data.active_mode === item._id ? <IconCheck size={16} /> : null}
+							onClick={() => layoutContext.actions.activateMode(item._id)}
+							rightSection={layoutContext.data.active_mode === item._id ? <IconCheck size={16} /> : null}
 						>
 							{item.name}
 						</Menu.Item>
@@ -61,8 +61,8 @@ export function TopbarOptions() {
 						<Menu.Item
 							key={item._id}
 							leftSection={<ColorSwatch color={item.primary_color} size={16} />}
-							onClick={() => themeContext.actions.activateTheme(item._id)}
-							rightSection={themeContext.data.active_theme === item._id ? <IconCheck size={16} /> : null}
+							onClick={() => layoutContext.actions.activateTheme(item._id)}
+							rightSection={layoutContext.data.active_theme === item._id ? <IconCheck size={16} /> : null}
 						>
 							{item.name}
 						</Menu.Item>

--- a/packages/ui/src/contexts/Layout.context.tsx
+++ b/packages/ui/src/contexts/Layout.context.tsx
@@ -34,7 +34,7 @@ export type ModeType = (typeof AVAILABLE_MODES)[number]['_id'];
 
 /* * */
 
-interface ThemeContextState {
+interface LayoutContextState {
 	actions: {
 		activateMode: (modeId: ModeType) => void
 		activateTheme: (themeId: ThemeType) => void
@@ -47,19 +47,19 @@ interface ThemeContextState {
 
 /* * */
 
-const ThemeContext = createContext<ThemeContextState | undefined>(undefined);
+const LayoutContext = createContext<LayoutContextState | undefined>(undefined);
 
-export function useThemeContext() {
-	const context = useContext(ThemeContext);
+export function useLayoutContext() {
+	const context = useContext(LayoutContext);
 	if (!context) {
-		throw new Error('useThemeContext must be used within a ThemeContextProvider');
+		throw new Error('useLayoutContext must be used within a LayoutContextProvider');
 	}
 	return context;
 }
 
 /* * */
 
-export const ThemeContextProvider = ({ children }: PropsWithChildren) => {
+export const LayoutContextProvider = ({ children }: PropsWithChildren) => {
 	//
 
 	//
@@ -112,7 +112,7 @@ export const ThemeContextProvider = ({ children }: PropsWithChildren) => {
 	//
 	// C. Define context value
 
-	const contextValue: ThemeContextState = useMemo(() => ({
+	const contextValue: LayoutContextState = useMemo(() => ({
 		actions: {
 			activateMode,
 			activateTheme,
@@ -130,9 +130,9 @@ export const ThemeContextProvider = ({ children }: PropsWithChildren) => {
 	// D. Render components
 
 	return (
-		<ThemeContext.Provider value={contextValue}>
+		<LayoutContext.Provider value={contextValue}>
 			{children}
-		</ThemeContext.Provider>
+		</LayoutContext.Provider>
 	);
 
 	//

--- a/packages/ui/src/contexts/index.ts
+++ b/packages/ui/src/contexts/index.ts
@@ -4,4 +4,4 @@ export * from './Me.context';
 export * from './Notifications.context';
 export * from './ProposedChanges.context';
 export * from './Sidebar.context';
-export * from './Theme.context';
+export * from './Layout.context';

--- a/packages/ui/src/providers/AppProvider/index.tsx
+++ b/packages/ui/src/providers/AppProvider/index.tsx
@@ -8,7 +8,7 @@ import { ExportsContextProvider } from '../../contexts/exports.context';
 import { MapContextProvider } from '../../contexts/Map.context';
 import { MeContextProvider } from '../../contexts/Me.context';
 import { NotificationsContextProvider } from '../../contexts/Notifications.context';
-import { ThemeContextProvider } from '../../contexts/Theme.context';
+import { LayoutContextProvider } from '../../contexts/Layout.context';
 
 /**
  * `AppProvider` component that wraps the application with necessary context providers.
@@ -20,11 +20,11 @@ export function AppProvider({ children }: PropsWithChildren) {
 		<MeContextProvider>
 			<NotificationsContextProvider>
 				<ExportsContextProvider>
-					<ThemeContextProvider>
+					<LayoutContextProvider>
 						<MapContextProvider>
 							{children}
 						</MapContextProvider>
-					</ThemeContextProvider>
+					</LayoutContextProvider>
 				</ExportsContextProvider>
 			</NotificationsContextProvider>
 		</MeContextProvider>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves Fastify multipart registration to the plans API, renames the UI Theme context to Layout context, and adjusts GTFS exporter stop_times and route tracking.
> 
> - **API**:
>   - Register `@fastify/multipart` in `modules/plans/apps/api/src/main.ts` with 2GB limit.
>   - Disable multipart registration in `packages/fastify/src/fastify-service.ts`.
> - **Exporter (GTFS merged)**:
>   - `stop_times`: use raw `stop_id` (remove plan-scoped prefix) in `exports/stop-times.ts`.
>   - Replace `Map` with object `Record` for `routesMarkedForFinalExport` and update access logic in `src/main.ts`.
> - **UI**:
>   - Rename and adopt `Theme` context → `Layout` context:
>     - New `packages/ui/src/contexts/Layout.context.tsx`; update hooks/exports.
>     - Replace providers in `AppProvider` and `modules/locations/.../layout.tsx`.
>     - Update `TopbarOptions` to use `Layout.context` for mode/theme switching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a860d98d3683ac9ce30705cc289d62c452f7720b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->