### PR TITLE
fix(alerts): include plan_id in service alert trip_id formatting

### DIFF
--- a/modules/alerts/apps/api/src/utils/service-alert-parser.ts
+++ b/modules/alerts/apps/api/src/utils/service-alert-parser.ts
@@ -62,7 +62,8 @@ async function parseServiceAlert(alert: Alert, lines: Line[]): Promise<ServiceAl
 				alert.references.forEach((reference) => {
 					informed_entity.push({
 						trip: {
-							trip_id: reference.parent_id.split('-').pop() ?? '',
+							// TODO: Should fetch from rides collection instead of regexing
+							trip_id: `[${reference.parent_id.split('-').shift() ?? ''}]${reference.parent_id.split('-').pop() ?? ''}`, // "[plan_id]-[trip_id]"
 						},
 					});
 				});


### PR DESCRIPTION
## Description

This PR fixes the trip_id formatting in the service alert parser to include both plan_id and trip_id in the format `[plan_id]-[trip_id]`.

## Changes

- Updated `parseServiceAlert` function in `service-alert-parser.ts` to extract both plan_id and trip_id from `reference.parent_id`
- Changed trip_id format from just the trip_id suffix to `[plan_id]-[trip_id]` format
- Added TODO comment noting that this should be refactored to fetch from rides collection instead of using string manipulation

## Context

Previously, the trip_id was extracted using `.split('-').pop()`, which only captured the trip_id portion. The new implementation uses both `.shift()` and `.pop()` to capture the plan_id prefix and trip_id suffix, formatting them as `[plan_id]-[trip_id]`.

## Type

- [x] Bug fix (hotfix)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update