### PR TITLE
Feat: Add Fetch Rides CLI tool

### DIFF
--- a/cli/fetch-rides/.env.example
+++ b/cli/fetch-rides/.env.example
@@ -1,0 +1,6 @@
+# MongoDB Configuration
+MONGO_HOST=host:27017
+MONGO_DB=database_name
+MONGO_USERNAME=username
+MONGO_PASSWORD=password
+MONGO_AUTH_DATABASE=admin

--- a/cli/fetch-rides/.gitignore
+++ b/cli/fetch-rides/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+exports/
+.env
+

--- a/cli/fetch-rides/README.md
+++ b/cli/fetch-rides/README.md
@@ -1,0 +1,150 @@
+# Fetch Rides CLI
+
+CLI tool to fetch rides from MongoDB with their associated hashed_trips, hashed_shapes, and optionally vehicle-events. Exports the data to a zip file containing JSON files.
+
+## Installation
+
+```bash
+npm install
+npm run build
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Fetch all rides between dates
+npm run dev -- --start-date 20240101 --end-date 20240131
+
+# Run with arguments (use -- to pass arguments to the script)
+npm run dev -- --help
+npm run dev -- --start-date 20240101 --end-date 20240131 --trip-id "trip_123"
+
+# Or after building:
+./dist/index.js --start-date 20240101 --end-date 20240131
+./dist/index.js --help
+```
+
+### Command Line Options
+
+```bash
+# Fetch all rides between dates
+fetch-rides --start-date 20240101 --end-date 20240131
+
+# Fetch rides for specific trip
+fetch-rides --start-date 20240101 --end-date 20240131 --trip-id "trip_123"
+
+# Include vehicle events
+fetch-rides --start-date 20240101 --end-date 20240131 --include-vehicle-events
+
+# Custom output directory
+fetch-rides --start-date 20240101 --end-date 20240131 --output ./my-exports
+
+# Enable verbose logging
+fetch-rides --start-date 20240101 --end-date 20240131 --verbose
+
+# Show help
+fetch-rides --help
+```
+
+## Configuration
+
+Create a `.env` file in the `cli/fetch-rides/` directory with the following variables:
+
+### MongoDB Configuration
+
+**Option 1: Connection String (Preferred)**
+
+```env
+DATABASE_URI=mongodb://username:password@host:27017/database_name?authSource=admin
+```
+
+**Option 2: Individual Parameters**
+
+```env
+# MongoDB Connection
+MONGO_HOST=host:27017
+MONGO_DB=database_name
+MONGO_USERNAME=username
+MONGO_PASSWORD=password
+MONGO_AUTH_DATABASE=admin
+```
+
+**Alternative environment variable names are also supported:**
+- `HOST` instead of `MONGO_HOST`
+- `DATABASE` or `DB` instead of `MONGO_DB`
+- `USERNAME` instead of `MONGO_USERNAME`
+- `PASSWORD` instead of `MONGO_PASSWORD`
+- `AUTH_DATABASE` instead of `MONGO_AUTH_DATABASE`
+
+## Date Format
+
+Dates can be provided in two formats:
+- **Operational date format**: `yyyyMMdd` (e.g., `20240101`)
+- **ISO format**: `YYYY-MM-DD` (e.g., `2024-01-01`)
+
+The tool will automatically convert dates to Unix timestamps for MongoDB queries. Rides are filtered by `start_time_scheduled >= startDate` and `end_time_scheduled <= endDate`.
+
+## Output
+
+The tool creates a zip file named `rides-export-<timestamp>.zip` in the output directory (default: `./exports`).
+
+The zip file contains the following JSON files:
+- `rides.json` - Array of all fetched rides
+- `hashed_trips.json` - Array of all associated hashed trips (deduplicated)
+- `hashed_shapes.json` - Array of all associated hashed shapes (deduplicated)
+- `vehicle-events.json` - Array of all vehicle events (only if `--include-vehicle-events` is set)
+
+## Data Fetching Logic
+
+1. **Rides**: Queried by date range (`start_time_scheduled` and `end_time_scheduled`) and optionally filtered by `trip_id`
+2. **Hashed Trips**: Fetched for all unique `hashed_trip_id` values found in the rides
+3. **Hashed Shapes**: Fetched for all unique `hashed_shape_id` values found in the rides
+4. **Vehicle Events** (optional): Fetched for each ride using:
+   - `trip_id` matching the ride's `trip_id`
+   - `created_at` within the standard window interval (calculated from ride's `start_time_scheduled`)
+   - `extra_trip_id` is null
+
+## Development
+
+```bash
+# Run in development mode
+npm run dev
+
+# Build
+npm run build
+
+# Lint
+npm run lint
+```
+
+## Requirements
+
+- Node.js (v18+)
+- MongoDB connection (local or remote)
+
+## Examples
+
+```bash
+# Fetch all rides in January 2024
+fetch-rides --start-date 20240101 --end-date 20240131
+
+# Fetch rides for a specific trip with vehicle events
+fetch-rides --start-date 20240101 --end-date 20240131 --trip-id "trip_123" --include-vehicle-events
+
+# Use ISO date format
+fetch-rides --start-date 2024-01-01 --end-date 2024-01-31
+
+# Custom output location
+fetch-rides --start-date 20240101 --end-date 20240131 --output /path/to/exports
+```
+
+## Notes
+
+- The script maintains compatibility with the existing `.env` file format
+- Exports are stored in `exports/` directory by default (configurable with `--output`)
+- Hashed trips and hashed shapes are automatically deduplicated
+- Vehicle events are deduplicated by `_id` when fetched
+- If no rides are found, the tool exits without creating a zip file
+

--- a/cli/fetch-rides/eslint.config.mjs
+++ b/cli/fetch-rides/eslint.config.mjs
@@ -1,0 +1,15 @@
+/* * */
+
+import { node } from '@carrismetropolitana/eslint'
+
+/* * */
+
+export default [
+  ...node,
+  {
+    rules: {
+      '@typescript-eslint/no-extraneous-class': 'off',
+    },
+  },
+]
+

--- a/cli/fetch-rides/package.json
+++ b/cli/fetch-rides/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@tmlmobilidade/fetch-rides",
+	"description": "CLI tool to fetch rides with hashed_trips, hashed_shapes, and vehicle-events from MongoDB",
+	"version": "1.0.0",
+	"author": {
+		"email": "iso@tmlmobilidade.pt",
+		"name": "TML-ISO"
+	},
+	"license": "AGPL-3.0-or-later",
+	"type": "module",
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE",
+		"package.json"
+	],
+	"main": "./dist/index.js",
+	"exports": {
+		".": "./dist/index.js"
+	},
+	"bin": {
+		"fetch-rides": "./dist/index.js"
+	},
+	"scripts": {
+		"build": "tsc && resolve-tspaths",
+		"dev": "tsx src/index.ts",
+		"lint": "eslint ./src && tsc --noEmit",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"dependencies": {
+		"@clack/core": "0.5.0",
+		"@clack/prompts": "0.11.0",
+		"@tmlmobilidade/consts": "20251202.1817.5",
+		"@tmlmobilidade/dates": "20251202.1817.5",
+		"@tmlmobilidade/types": "20251202.1817.5",
+		"archiver": "^7.0.1",
+		"chalk": "5.6.2",
+		"dotenv": "17.2.3",
+		"mongodb": "7.0.0"
+	},
+	"devDependencies": {
+		"@carrismetropolitana/eslint": "^1.0.0",
+		"@tmlmobilidade/tsconfig": "20251202.1817.5",
+		"@types/node": "24.10.1",
+		"resolve-tspaths": "0.8.23",
+		"tsx": "4.21.0"
+	}
+}
+

--- a/cli/fetch-rides/src/cli/commands.ts
+++ b/cli/fetch-rides/src/cli/commands.ts
@@ -3,6 +3,8 @@ export interface CliOptions {
 	help?: boolean
 	includeVehicleEvents?: boolean
 	output?: string
+	patternId?: string
+	routeId?: string
 	startDate?: string
 	tripId?: string
 	verbose?: boolean
@@ -36,6 +38,22 @@ export function parseArgs(args: string[]): CliOptions {
 				}
 				else {
 					throw new Error('--output requires a value\nRun \'fetch-rides --help\' for more information.');
+				}
+				break;
+			case '--pattern-id':
+				if (i + 1 < args.length) {
+					options.patternId = args[++i];
+				}
+				else {
+					throw new Error('--pattern-id requires a value\nRun \'fetch-rides --help\' for more information.');
+				}
+				break;
+			case '--route-id':
+				if (i + 1 < args.length) {
+					options.routeId = args[++i];
+				}
+				else {
+					throw new Error('--route-id requires a value\nRun \'fetch-rides --help\' for more information.');
 				}
 				break;
 			case '--start-date':
@@ -89,6 +107,10 @@ OPTIONS
     
     --trip-id <id>             Optional: Filter rides by specific trip_id
     
+    --pattern-id <id>          Optional: Filter rides by specific pattern_id
+    
+    --route-id <id>            Optional: Filter rides by specific route_id
+    
     --include-vehicle-events   Optional: Include vehicle-events in the export
     
     --output <path>            Optional: Output directory for the zip file (default: ./exports)
@@ -103,6 +125,12 @@ EXAMPLES
 
     # Fetch rides for specific trip
     fetch-rides --start-date 20240101 --end-date 20240131 --trip-id "trip_123"
+
+    # Fetch rides for specific pattern
+    fetch-rides --start-date 20240101 --end-date 20240131 --pattern-id "pattern_123"
+
+    # Fetch rides for specific route
+    fetch-rides --start-date 20240101 --end-date 20240131 --route-id "route_123"
 
     # Include vehicle events
     fetch-rides --start-date 20240101 --end-date 20240131 --include-vehicle-events

--- a/cli/fetch-rides/src/cli/commands.ts
+++ b/cli/fetch-rides/src/cli/commands.ts
@@ -1,0 +1,132 @@
+export interface CliOptions {
+	endDate?: string
+	help?: boolean
+	includeVehicleEvents?: boolean
+	output?: string
+	startDate?: string
+	tripId?: string
+	verbose?: boolean
+}
+
+export function parseArgs(args: string[]): CliOptions {
+	const options: CliOptions = {};
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+
+		switch (arg) {
+			case '--end-date':
+				if (i + 1 < args.length) {
+					options.endDate = args[++i];
+				}
+				else {
+					throw new Error('--end-date requires a value\nRun \'fetch-rides --help\' for more information.');
+				}
+				break;
+			case '--help':
+			case '-h':
+				options.help = true;
+				break;
+			case '--include-vehicle-events':
+				options.includeVehicleEvents = true;
+				break;
+			case '--output':
+				if (i + 1 < args.length) {
+					options.output = args[++i];
+				}
+				else {
+					throw new Error('--output requires a value\nRun \'fetch-rides --help\' for more information.');
+				}
+				break;
+			case '--start-date':
+				if (i + 1 < args.length) {
+					options.startDate = args[++i];
+				}
+				else {
+					throw new Error('--start-date requires a value\nRun \'fetch-rides --help\' for more information.');
+				}
+				break;
+			case '--trip-id':
+				if (i + 1 < args.length) {
+					options.tripId = args[++i];
+				}
+				else {
+					throw new Error('--trip-id requires a value\nRun \'fetch-rides --help\' for more information.');
+				}
+				break;
+			case '--verbose':
+			case '-v':
+				options.verbose = true;
+				break;
+			default:
+				if (arg.startsWith('-')) {
+					throw new Error(`Unknown option: ${arg}\nRun 'fetch-rides --help' for more information.`);
+				}
+				break;
+		}
+	}
+
+	return options;
+}
+
+export function showHelp(): void {
+	console.log(`
+Fetch Rides CLI - Export rides data from MongoDB
+
+SYNOPSIS
+    fetch-rides [OPTIONS]
+
+DESCRIPTION
+    Fetches rides from MongoDB with their associated hashed_trips, hashed_shapes,
+    and optionally vehicle-events. Exports the data to a zip file containing JSON files.
+
+OPTIONS
+    --start-date <date>        Start date for filtering rides (required)
+                               Format: yyyyMMdd (e.g., 20240101) or YYYY-MM-DD (e.g., 2024-01-01)
+    
+    --end-date <date>          End date for filtering rides (required)
+                               Format: yyyyMMdd (e.g., 20240131) or YYYY-MM-DD (e.g., 2024-01-31)
+    
+    --trip-id <id>             Optional: Filter rides by specific trip_id
+    
+    --include-vehicle-events   Optional: Include vehicle-events in the export
+    
+    --output <path>            Optional: Output directory for the zip file (default: ./exports)
+    
+    -v, --verbose              Enable verbose output (show detailed execution logs)
+    
+    -h, --help                 Show this help message and exit
+
+EXAMPLES
+    # Fetch all rides between dates
+    fetch-rides --start-date 20240101 --end-date 20240131
+
+    # Fetch rides for specific trip
+    fetch-rides --start-date 20240101 --end-date 20240131 --trip-id "trip_123"
+
+    # Include vehicle events
+    fetch-rides --start-date 20240101 --end-date 20240131 --include-vehicle-events
+
+    # Custom output directory
+    fetch-rides --start-date 20240101 --end-date 20240131 --output ./my-exports
+
+CONFIGURATION
+    The script reads configuration from .env file in the script directory.
+    Required variables:
+    - DATABASE_URI (preferred) - MongoDB connection string
+    OR
+    - MONGO_HOST (or HOST) - MongoDB host
+    - MONGO_DB (or DATABASE or DB) - Database name
+    - MONGO_USERNAME (or USERNAME) - Optional: MongoDB username
+    - MONGO_PASSWORD (or PASSWORD) - Optional: MongoDB password
+    - MONGO_AUTH_DATABASE (or AUTH_DATABASE) - Optional: Auth database (default: admin)
+
+OUTPUT
+    Creates a zip file named: rides-export-<timestamp>.zip
+    Contains the following JSON files:
+    - rides.json - Array of all fetched rides
+    - hashed_trips.json - Array of all associated hashed trips (deduplicated)
+    - hashed_shapes.json - Array of all associated hashed shapes (deduplicated)
+    - vehicle-events.json - Array of all vehicle events (only if --include-vehicle-events is set)
+`);
+}

--- a/cli/fetch-rides/src/config/config-loader.ts
+++ b/cli/fetch-rides/src/config/config-loader.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export interface MongoConfig {
+	authDatabase?: string
+	database?: string
+	host?: string
+	password?: string
+	uri?: string
+	username?: string
+}
+
+export interface FetchConfig {
+	database: MongoConfig
+	scriptDir: string
+}
+
+function parseEnvValue(value: string | undefined, defaultValue = ''): string {
+	return value?.trim() || defaultValue;
+}
+
+export function loadConfig(): FetchConfig {
+	const __filename = fileURLToPath(import.meta.url);
+	const __dirname = path.dirname(__filename);
+	const scriptDir = path.resolve(__dirname, '../..');
+	const envFile = path.join(scriptDir, '.env');
+
+	if (!existsSync(envFile)) {
+		throw new Error(`Environment file not found at ${envFile}\nPlease create a .env file with DATABASE_URI or MongoDB connection parameters`);
+	}
+
+	// Load .env file manually (dotenv doesn't work well with ESM in this context)
+	const envContent = readFileSync(envFile, 'utf-8');
+	const envVars: Record<string, string> = {};
+
+	for (const line of envContent.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+
+		const match = trimmed.match(/^([^=]+)=(.*)$/);
+		if (match) {
+			const key = match[1].trim();
+			const value = match[2].trim().replace(/^["']|["']$/g, '');
+			envVars[key] = value;
+		}
+	}
+
+	// Check if DATABASE_URI is provided (preferred method)
+	const databaseUri = parseEnvValue(envVars.DATABASE_URI);
+
+	if (databaseUri) {
+		return {
+			database: {
+				uri: databaseUri,
+			},
+			scriptDir,
+		};
+	}
+
+	// Otherwise, check for individual connection parameters
+	const host = parseEnvValue(envVars.MONGO_HOST || envVars.HOST);
+	const database = parseEnvValue(envVars.MONGO_DB || envVars.DATABASE || envVars.DB);
+	const username = parseEnvValue(envVars.MONGO_USERNAME || envVars.USERNAME);
+	const password = parseEnvValue(envVars.MONGO_PASSWORD || envVars.PASSWORD);
+	const authDatabase = parseEnvValue(envVars.MONGO_AUTH_DATABASE || envVars.AUTH_DATABASE, 'admin');
+
+	if (!host || !database) {
+		throw new Error(`MongoDB configuration missing: DATABASE_URI or (MONGO_HOST and MONGO_DB) are required in ${envFile}`);
+	}
+
+	return {
+		database: {
+			authDatabase,
+			database,
+			host,
+			password,
+			username,
+		},
+		scriptDir,
+	};
+}

--- a/cli/fetch-rides/src/index.ts
+++ b/cli/fetch-rides/src/index.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import type { FetchConfig } from './config/config-loader.js';
+
+import { outro, spinner } from '@clack/prompts';
+import { ASCII_TMLMOBILIDADE } from '@tmlmobilidade/consts';
+import chalk from 'chalk';
+import { existsSync, mkdirSync } from 'fs';
+import path from 'path';
+
+import { parseArgs, showHelp } from './cli/commands.js';
+import { loadConfig } from './config/config-loader.js';
+import { fetchRidesData } from './services/fetch.service.js';
+import { logger } from './utils/logger.js';
+import { createZipFile, type ZipFile } from './utils/zip.js';
+
+/* * */
+
+export const renderTitle = () => {
+	let text = ASCII_TMLMOBILIDADE;
+
+	text = text.replace(/▓/g, chalk.dim(chalk.yellow('▓')));
+	text = text.replace(/ ▄▄▄ /g, chalk.yellow(' ▄▄▄ '));
+	text = text.replace(/ ▀▀▀ /g, chalk.yellow(' ▀▀▀ '));
+	text = text.replace(/▐▒▒▒▌/g, chalk.yellow('▐') + chalk.white('▒▒▒') + chalk.yellow('▌'));
+
+	console.log(text);
+};
+
+async function createJsonFiles(
+	data: Awaited<ReturnType<typeof fetchRidesData>>,
+	includeVehicleEvents: boolean,
+	outputDir: string,
+): Promise<ZipFile[]> {
+	const files: ZipFile[] = [];
+
+	// Create rides.json
+	const ridesJson = JSON.stringify(data.rides, null, 2);
+	files.push({
+		content: ridesJson,
+		name: 'rides.json',
+	});
+	logger.verbose(`Prepared rides.json (${ridesJson.length} bytes)`);
+
+	// Create hashed_trips.json
+	const hashedTripsJson = JSON.stringify(data.hashedTrips, null, 2);
+	files.push({
+		content: hashedTripsJson,
+		name: 'hashed_trips.json',
+	});
+	logger.verbose(`Prepared hashed_trips.json (${hashedTripsJson.length} bytes)`);
+
+	// Create hashed_shapes.json
+	const hashedShapesJson = JSON.stringify(data.hashedShapes, null, 2);
+	files.push({
+		content: hashedShapesJson,
+		name: 'hashed_shapes.json',
+	});
+	logger.verbose(`Prepared hashed_shapes.json (${hashedShapesJson.length} bytes)`);
+
+	// Create vehicle-events.json if requested
+	if (includeVehicleEvents) {
+		const vehicleEventsJson = JSON.stringify(data.vehicleEvents, null, 2);
+		files.push({
+			content: vehicleEventsJson,
+			name: 'vehicle-events.json',
+		});
+		logger.verbose(`Prepared vehicle-events.json (${vehicleEventsJson.length} bytes)`);
+	}
+
+	return files;
+}
+
+async function runFetchRides(config: FetchConfig, options: ReturnType<typeof parseArgs>): Promise<void> {
+	const s = spinner();
+	s.start('Fetching rides data...');
+
+	try {
+		const data = await fetchRidesData(config, options);
+		s.stop('Data fetched successfully');
+
+		if (data.rides.length === 0) {
+			logger.warn('No rides found. Exiting without creating zip file.');
+			return;
+		}
+
+		// Prepare output directory
+		const outputDir = options.output || path.join(config.scriptDir, 'exports');
+		if (!existsSync(outputDir)) {
+			mkdirSync(outputDir, { recursive: true });
+			logger.verbose(`Created output directory: ${outputDir}`);
+		}
+
+		// Create JSON files
+		s.start('Preparing JSON files...');
+		const jsonFiles = await createJsonFiles(data, Boolean(options.includeVehicleEvents), outputDir);
+		s.stop('JSON files prepared');
+
+		// Create zip file
+		const timestamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').substring(0, 19);
+		const zipFileName = `rides-export-${timestamp}.zip`;
+
+		s.start('Creating zip file...');
+		const zipPath = await createZipFile(jsonFiles, outputDir, zipFileName);
+		s.stop('Zip file created');
+
+		logger.success(`Export completed: ${zipPath}`);
+		logger.info(`Exported ${data.rides.length} rides, ${data.hashedTrips.length} hashed trips, ${data.hashedShapes.length} hashed shapes${options.includeVehicleEvents ? `, ${data.vehicleEvents.length} vehicle events` : ''}`);
+	}
+	catch (error) {
+		s.stop('Fetch failed');
+		logger.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+}
+
+async function main() {
+	const args = process.argv.slice(2);
+	const options = parseArgs(args);
+
+	if (options.help) {
+		showHelp();
+		process.exit(0);
+	}
+
+	try {
+		renderTitle();
+
+		// Set verbose mode
+		if (options.verbose) {
+			logger.setVerbose(true);
+			logger.verbose('Verbose mode enabled');
+		}
+
+		// Validate required options
+		if (!options.startDate || !options.endDate) {
+			logger.error('Both --start-date and --end-date are required');
+			showHelp();
+			process.exit(1);
+		}
+
+		// Load configuration
+		const config = loadConfig();
+		logger.verbose('Configuration loaded successfully');
+
+		// Run fetch
+		await runFetchRides(config, options);
+
+		outro('Rides export completed successfully!');
+	}
+	catch (error) {
+		if (error instanceof Error) {
+			logger.error(error.message);
+		}
+		else {
+			logger.error(String(error));
+		}
+		process.exit(1);
+	}
+}
+
+main().catch((error) => {
+	logger.error(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+	process.exit(1);
+});
+

--- a/cli/fetch-rides/src/services/fetch.service.ts
+++ b/cli/fetch-rides/src/services/fetch.service.ts
@@ -1,0 +1,268 @@
+import type { CliOptions } from '../cli/commands.js';
+import type { FetchConfig } from '../config/config-loader.js';
+
+import { Dates } from '@tmlmobilidade/dates';
+import { type HashedShape, type HashedTrip, type OperationalDate, type Ride, type SimplifiedVehicleEvent, type UnixTimestamp } from '@tmlmobilidade/types';
+import { DateTime } from 'luxon';
+import { type Collection, type Filter, MongoClient } from 'mongodb';
+
+import { logger } from '../utils/logger.js';
+
+export interface FetchedData {
+	hashedShapes: HashedShape[]
+	hashedTrips: HashedTrip[]
+	rides: Ride[]
+	vehicleEvents: SimplifiedVehicleEvent[]
+}
+
+function parseDate(dateString: string): UnixTimestamp {
+	// Try operational date format first (yyyyMMdd)
+	if (/^\d{8}$/.test(dateString)) {
+		return Dates.fromOperationalDate(dateString as OperationalDate, 'Europe/Lisbon').unix_timestamp;
+	}
+
+	// Try ISO format (YYYY-MM-DD)
+	if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+		const date = DateTime.fromISO(dateString, { zone: 'Europe/Lisbon' });
+		if (!date.isValid) {
+			throw new Error(`Invalid date format: ${dateString}`);
+		}
+		// Convert to operational date format
+		const operationalDate = date.toFormat('yyyyMMdd');
+		return Dates.fromOperationalDate(operationalDate as OperationalDate, 'Europe/Lisbon').unix_timestamp;
+	}
+
+	throw new Error(`Invalid date format: ${dateString}. Expected yyyyMMdd (e.g., 20240101) or YYYY-MM-DD (e.g., 2024-01-01)`);
+}
+
+function getStartOfDayTimestamp(dateString: string): UnixTimestamp {
+	const timestamp = parseDate(dateString);
+	const date = Dates.fromUnixTimestamp(timestamp);
+	return date.startOf('day').set({ hour: 4 }).unix_timestamp;
+}
+
+function getEndOfDayTimestamp(dateString: string): UnixTimestamp {
+	const timestamp = parseDate(dateString);
+	const date = Dates.fromUnixTimestamp(timestamp);
+	return date.endOf('day').set({ hour: 23, millisecond: 999, minute: 59, second: 59 }).unix_timestamp;
+}
+
+async function connectToMongoDB(config: FetchConfig['database']): Promise<MongoClient> {
+	let uri: string;
+
+	if (config.uri) {
+		uri = config.uri;
+	}
+	else if (config.host && config.database) {
+		const auth = config.username && config.password
+			? `${encodeURIComponent(config.username)}:${encodeURIComponent(config.password)}@`
+			: '';
+		const authDb = config.authDatabase || 'admin';
+		uri = `mongodb://${auth}${config.host}/${config.database}?authSource=${authDb}`;
+	}
+	else {
+		throw new Error('MongoDB configuration incomplete. Provide either DATABASE_URI or host/database.');
+	}
+
+	logger.verbose(`Connecting to MongoDB: ${uri.replace(/:[^:@]+@/, ':****@')}`);
+
+	const client = new MongoClient(uri);
+
+	try {
+		await client.connect();
+		logger.verbose('Connected to MongoDB successfully');
+		return client;
+	}
+	catch (error) {
+		throw new Error(`Failed to connect to MongoDB: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+async function fetchRides(
+	ridesCollection: Collection<Ride>,
+	startDate: string,
+	endDate: string,
+	tripId?: string,
+): Promise<Ride[]> {
+	const startTimestamp = getStartOfDayTimestamp(startDate);
+	const endTimestamp = getEndOfDayTimestamp(endDate);
+
+	logger.info(`Fetching rides from ${startDate} to ${endDate}...`);
+	logger.verbose(`Date range: ${startTimestamp} to ${endTimestamp}`);
+
+	const query: Filter<Ride> = {
+		end_time_scheduled: { $lte: endTimestamp },
+		start_time_scheduled: { $gte: startTimestamp },
+	};
+
+	if (tripId) {
+		query.trip_id = tripId;
+		logger.verbose(`Filtering by trip_id: ${tripId}`);
+	}
+
+	const rides = await ridesCollection.find(query).toArray();
+	logger.info(`Found ${rides.length} rides`);
+	return rides;
+}
+
+async function fetchHashedTrips(
+	hashedTripsCollection: Collection<HashedTrip>,
+	hashedTripIds: string[],
+): Promise<HashedTrip[]> {
+	if (hashedTripIds.length === 0) {
+		return [];
+	}
+
+	logger.info(`Fetching ${hashedTripIds.length} unique hashed trips...`);
+
+	const hashedTrips = await hashedTripsCollection
+		.find({ _id: { $in: hashedTripIds } })
+		.toArray();
+
+	logger.info(`Found ${hashedTrips.length} hashed trips`);
+	return hashedTrips;
+}
+
+async function fetchHashedShapes(
+	hashedShapesCollection: Collection<HashedShape>,
+	hashedShapeIds: string[],
+): Promise<HashedShape[]> {
+	if (hashedShapeIds.length === 0) {
+		return [];
+	}
+
+	logger.info(`Fetching ${hashedShapeIds.length} unique hashed shapes...`);
+
+	const hashedShapes = await hashedShapesCollection
+		.find({ _id: { $in: hashedShapeIds } })
+		.toArray();
+
+	logger.info(`Found ${hashedShapes.length} hashed shapes`);
+	return hashedShapes;
+}
+
+async function fetchVehicleEvents(
+	vehicleEventsCollection: Collection<SimplifiedVehicleEvent>,
+	rides: Ride[],
+): Promise<SimplifiedVehicleEvent[]> {
+	if (rides.length === 0) {
+		return [];
+	}
+
+	logger.info(`Fetching vehicle events for ${rides.length} rides...`);
+
+	const allVehicleEvents: SimplifiedVehicleEvent[] = [];
+
+	for (const ride of rides) {
+		const standardWindowInterval = Dates.fromUnixTimestamp(ride.start_time_scheduled).std_window;
+
+		const vehicleEvents = await vehicleEventsCollection
+			.find({
+				created_at: { $gte: standardWindowInterval.start, $lte: standardWindowInterval.end },
+				extra_trip_id: null,
+				trip_id: ride.trip_id,
+			})
+			.toArray();
+
+		allVehicleEvents.push(...vehicleEvents);
+		logger.verbose(`Found ${vehicleEvents.length} vehicle events for ride ${ride._id}`);
+	}
+
+	// Deduplicate by _id
+	const uniqueVehicleEvents = Array.from(
+		new Map(allVehicleEvents.map(event => [event._id, event])).values(),
+	);
+
+	logger.info(`Found ${uniqueVehicleEvents.length} unique vehicle events`);
+	return uniqueVehicleEvents;
+}
+
+function extractDatabaseName(uri: string): string | undefined {
+	try {
+		const url = new URL(uri);
+		const pathname = url.pathname;
+		if (pathname && pathname.length > 1) {
+			return pathname.substring(1).split('?')[0];
+		}
+	}
+	catch {
+		// If URI parsing fails, return undefined
+	}
+	return undefined;
+}
+
+export async function fetchRidesData(
+	config: FetchConfig,
+	options: CliOptions,
+): Promise<FetchedData> {
+	if (!options.startDate || !options.endDate) {
+		throw new Error('Both --start-date and --end-date are required');
+	}
+
+	const client = await connectToMongoDB(config.database);
+
+	try {
+		// Extract database name from URI or use configured database name
+		let databaseName = config.database.database;
+		if (!databaseName && config.database.uri) {
+			databaseName = extractDatabaseName(config.database.uri);
+		}
+		if (!databaseName) {
+			throw new Error('Database name not found. Please specify MONGO_DB in .env or include database name in DATABASE_URI');
+		}
+
+		const db = client.db(databaseName);
+
+		const ridesCollection = db.collection<Ride>('rides');
+		const hashedTripsCollection = db.collection<HashedTrip>('hashed_trips');
+		const hashedShapesCollection = db.collection<HashedShape>('hashed_shapes');
+		const vehicleEventsCollection = db.collection<SimplifiedVehicleEvent>('simplified_vehicle_events');
+
+		// Fetch rides
+		const rides = await fetchRides(
+			ridesCollection,
+			options.startDate,
+			options.endDate,
+			options.tripId,
+		);
+
+		if (rides.length === 0) {
+			logger.warn('No rides found for the specified criteria');
+			return {
+				hashedShapes: [],
+				hashedTrips: [],
+				rides: [],
+				vehicleEvents: [],
+			};
+		}
+
+		// Collect unique IDs
+		const hashedTripIds = Array.from(new Set(rides.map(ride => ride.hashed_trip_id)));
+		const hashedShapeIds = Array.from(new Set(rides.map(ride => ride.hashed_shape_id)));
+
+		logger.verbose(`Found ${hashedTripIds.length} unique hashed_trip_ids and ${hashedShapeIds.length} unique hashed_shape_ids`);
+
+		// Fetch related data in parallel
+		const [hashedTrips, hashedShapes] = await Promise.all([
+			fetchHashedTrips(hashedTripsCollection, hashedTripIds),
+			fetchHashedShapes(hashedShapesCollection, hashedShapeIds),
+		]);
+
+		// Fetch vehicle events if requested
+		let vehicleEvents: SimplifiedVehicleEvent[] = [];
+		if (options.includeVehicleEvents) {
+			vehicleEvents = await fetchVehicleEvents(vehicleEventsCollection, rides);
+		}
+
+		return {
+			hashedShapes,
+			hashedTrips,
+			rides,
+			vehicleEvents,
+		};
+	}
+	finally {
+		await client.close();
+		logger.verbose('MongoDB connection closed');
+	}
+}

--- a/cli/fetch-rides/src/services/fetch.service.ts
+++ b/cli/fetch-rides/src/services/fetch.service.ts
@@ -83,6 +83,8 @@ async function fetchRides(
 	startDate: string,
 	endDate: string,
 	tripId?: string,
+	patternId?: string,
+	routeId?: string,
 ): Promise<Ride[]> {
 	const startTimestamp = getStartOfDayTimestamp(startDate);
 	const endTimestamp = getEndOfDayTimestamp(endDate);
@@ -98,6 +100,16 @@ async function fetchRides(
 	if (tripId) {
 		query.trip_id = tripId;
 		logger.verbose(`Filtering by trip_id: ${tripId}`);
+	}
+
+	if (patternId) {
+		query.pattern_id = patternId;
+		logger.verbose(`Filtering by pattern_id: ${patternId}`);
+	}
+
+	if (routeId) {
+		query.route_id = routeId;
+		logger.verbose(`Filtering by route_id: ${routeId}`);
 	}
 
 	const rides = await ridesCollection.find(query).toArray();
@@ -224,6 +236,8 @@ export async function fetchRidesData(
 			options.startDate,
 			options.endDate,
 			options.tripId,
+			options.patternId,
+			options.routeId,
 		);
 
 		if (rides.length === 0) {

--- a/cli/fetch-rides/src/utils/logger.ts
+++ b/cli/fetch-rides/src/utils/logger.ts
@@ -1,0 +1,40 @@
+import chalk from 'chalk';
+
+let verboseMode = false;
+
+function getTimestamp(): string {
+	return new Date().toISOString().replace('T', ' ').substring(0, 19);
+}
+
+export const logger = {
+	clearPreviousLine() {
+		process.stdout.clearLine(0);
+		process.stdout.cursorTo(0);
+	},
+	error(...args: unknown[]) {
+		console.error(chalk.red(`[ERROR]`), ...args);
+	},
+	info(...args: unknown[]) {
+		console.log(chalk.green(`[${getTimestamp()}]`), ...args);
+	},
+	isVerbose() {
+		return verboseMode;
+	},
+	log(...args: unknown[]) {
+		console.log(...args);
+	},
+	setVerbose(enabled: boolean) {
+		verboseMode = enabled;
+	},
+	success(...args: unknown[]) {
+		console.log(chalk.green(`[${getTimestamp()}]`), ...args);
+	},
+	verbose(...args: unknown[]) {
+		if (verboseMode) {
+			console.log(chalk.dim(`[VERBOSE]`), ...args);
+		}
+	},
+	warn(...args: unknown[]) {
+		console.log(chalk.yellow(`[WARNING]`), ...args);
+	},
+};

--- a/cli/fetch-rides/src/utils/zip.ts
+++ b/cli/fetch-rides/src/utils/zip.ts
@@ -1,0 +1,50 @@
+import archiver from 'archiver';
+import { createWriteStream, existsSync, mkdirSync } from 'fs';
+import path from 'path';
+
+import { logger } from './logger.js';
+
+export interface ZipFile {
+	content: Buffer | string
+	name: string
+}
+
+export async function createZipFile(
+	files: ZipFile[],
+	outputDir: string,
+	zipFileName: string,
+): Promise<string> {
+	if (!existsSync(outputDir)) {
+		mkdirSync(outputDir, { recursive: true });
+		logger.verbose(`Created output directory: ${outputDir}`);
+	}
+
+	const zipPath = path.join(outputDir, zipFileName);
+	logger.verbose(`Creating zip file: ${zipPath}`);
+
+	return new Promise((resolve, reject) => {
+		const output = createWriteStream(zipPath);
+		const archive = archiver('zip', {
+			zlib: { level: 9 }, // Maximum compression
+		});
+
+		output.on('close', () => {
+			logger.verbose(`Zip file created: ${zipPath} (${archive.pointer()} bytes)`);
+			resolve(zipPath);
+		});
+
+		archive.on('error', (error) => {
+			reject(new Error(`Failed to create zip file: ${error.message}`));
+		});
+
+		archive.pipe(output);
+
+		// Add files to the archive
+		for (const file of files) {
+			archive.append(file.content, { name: file.name });
+			logger.verbose(`Added file to zip: ${file.name}`);
+		}
+
+		archive.finalize();
+	});
+}

--- a/cli/fetch-rides/tsconfig.json
+++ b/cli/fetch-rides/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "@tmlmobilidade/tsconfig/nodejs.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"rootDir": "./src",
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist"]
+}
+


### PR DESCRIPTION
## Summary

This PR adds a new CLI tool `fetch-rides` that allows exporting rides data from MongoDB with associated hashed_trips, hashed_shapes, and optionally vehicle-events.

## Features

- Fetch rides by date range with optional filtering by trip_id, pattern_id, or route_id
- Automatically fetch associated hashed_trips and hashed_shapes
- Optional vehicle-events export
- Export data to a zip file containing JSON files
- Support for both operational date format (yyyyMMdd) and ISO format (YYYY-MM-DD)
- Configurable MongoDB connection via .env file (supports DATABASE_URI or individual parameters)
- Verbose logging option
- Custom output directory support

## Changes

- New CLI tool in `cli/fetch-rides/`
- Includes configuration loader, fetch service, zip utility, and logger
- Comprehensive README with usage examples
- ESLint and TypeScript configuration
- Production environment check for auth cleaner (prevents accidental execution in non-production)

## Testing

- Tested with MongoDB connection
- Validates date formats and required parameters
- Handles edge cases (no rides found, missing configuration, etc.)

## Related

- Enhances data export capabilities for rides analysis