### PR TITLE
Add search query support to rides export

### DIFF
--- a/modules/controller/apps/frontend/src/contexts/RidesExport.context.tsx
+++ b/modules/controller/apps/frontend/src/contexts/RidesExport.context.tsx
@@ -89,6 +89,7 @@ export const RidesExportModalContextProvider = ({ children, initialFilters }: Pr
 				date_start: filterDateStart as UnixTimestamp,
 				delay_statuses: filterDelayStatus as DelayStatus[],
 				operational_statuses: filterOperationalStatus as OperationalStatus[],
+				search: initialFilters.search || undefined,
 			},
 			type: 'ride',
 		};

--- a/modules/exporter/apps/export-files/src/export-rides.ts
+++ b/modules/exporter/apps/export-files/src/export-rides.ts
@@ -32,8 +32,15 @@ export async function exportRidesFile(fileExport: FileExport): Promise<string> {
 	await fileExports.updateById(fileExport._id, { processing_status: 'processing' });
 
 	//
+	// Extract and prepare the search query
+	const searchQuery = (fileExport.properties as typeof fileExport.properties & { search?: string }).search?.trim() ?? '';
+
+	//
 	// Get the rides batch using native MongoDB cursor with batchSize to prevent memory issues
-	const pipeline = ridesBatchAggregationPipeline(fileExport.properties);
+	const pipeline = ridesBatchAggregationPipeline({
+		...fileExport.properties,
+		search: searchQuery || undefined,
+	});
 
 	//
 	// 4. Filter rides based on permissions for the current user

--- a/packages/types/src/file-exports/ride-export.ts
+++ b/packages/types/src/file-exports/ride-export.ts
@@ -141,6 +141,7 @@ export const RideExportPropertiesSchema = z.object({
 
 		/* * */
 		acceptance_status: z.array(z.enum([...RideAcceptanceStatusSchema.options, 'none'])).optional().nullable(),
+		search: z.string().optional().nullable(),
 	}),
 	type: z.literal('ride'),
 });


### PR DESCRIPTION
This PR adds search query functionality to the rides export feature.

## Changes
- Added `search` field to `RideExportPropertiesSchema` in the types package
- Updated `exportRidesFile` function to extract and use the search query from export properties
- Updated `RidesExportModalContext` to include search query in the export request

## Testing
- Export functionality should now filter rides by search query when provided
- Existing exports without search query continue to work as before

## Related
- Follows the same pattern as the rides controller's search functionality