### PR TITLE
Adiciona Geohash, H3, campo do Current Status do GTFS RT

### DIFF
--- a/modules/replicator/apps/stream/package.json
+++ b/modules/replicator/apps/stream/package.json
@@ -21,7 +21,8 @@
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/logger": "*",
 		"@tmlmobilidade/timer": "*",
-		"@tmlmobilidade/utils": "*"
+		"@tmlmobilidade/utils": "*",
+		"@tmlmobilidade/writers": "*"
 	},
 	"devDependencies": {
 		"@tmlmobilidade/tsconfig": "*",

--- a/modules/replicator/apps/stream/package.json
+++ b/modules/replicator/apps/stream/package.json
@@ -17,7 +17,6 @@
 		"lint:fix": "eslint . --fix"
 	},
 	"dependencies": {
-		"@tmlmobilidade/writers": "*",
 		"@tmlmobilidade/go-replicator-pckg-parse": "*",
 		"@tmlmobilidade/interfaces": "*",
 		"@tmlmobilidade/logger": "*",

--- a/modules/replicator/packages/parse/package.json
+++ b/modules/replicator/packages/parse/package.json
@@ -18,12 +18,12 @@
 		"@tmlmobilidade/go-replicator-pckg-sync": "*",
 		"@tmlmobilidade/types": "*",
 		"@tmlmobilidade/utils": "*",
-		"h3-js": "^4.4.0",
-		"ngeohash": "^0.6.3"
+		"h3-js": "4.4.0",
+		"ngeohash": "0.6.3"
 	},
 	"devDependencies": {
 		"@tmlmobilidade/tsconfig": "*",
-		"@types/ngeohash": "^0.6.8",
+		"@types/ngeohash": "0.6.8",
 		"@types/node": "25.0.3",
 		"resolve-tspaths": "0.8.23",
 		"tsc-watch": "7.2.0",

--- a/modules/replicator/packages/parse/package.json
+++ b/modules/replicator/packages/parse/package.json
@@ -17,10 +17,13 @@
 	"dependencies": {
 		"@tmlmobilidade/go-replicator-pckg-sync": "*",
 		"@tmlmobilidade/types": "*",
-		"@tmlmobilidade/utils": "*"
+		"@tmlmobilidade/utils": "*",
+		"h3-js": "^4.4.0",
+		"ngeohash": "^0.6.3"
 	},
 	"devDependencies": {
 		"@tmlmobilidade/tsconfig": "*",
+		"@types/ngeohash": "^0.6.8",
 		"@types/node": "25.0.3",
 		"resolve-tspaths": "0.8.23",
 		"tsc-watch": "7.2.0",

--- a/modules/replicator/packages/parse/src/parse-vehicle-event.ts
+++ b/modules/replicator/packages/parse/src/parse-vehicle-event.ts
@@ -2,6 +2,8 @@
 
 import { Dates } from '@tmlmobilidade/dates';
 import { type SimplifiedVehicleEvent } from '@tmlmobilidade/types';
+import { latLngToCell } from 'h3-js';
+import { encode } from 'ngeohash';
 
 /* * */
 
@@ -12,13 +14,18 @@ export function parseVehicleEvent(pcgiDoc: any): null | SimplifiedVehicleEvent {
 			_id: pcgiDoc._id,
 			agency_id: pcgiDoc.content.entity[0].vehicle.agencyId,
 			created_at: Dates.fromSeconds(pcgiDoc.content.entity[0].vehicle.timestamp).unix_timestamp,
+			current_status: pcgiDoc.content.entity[0].vehicle.currentStatus,
 			driver_id: pcgiDoc.content.entity[0].vehicle.vehicle.driverId,
 			event_id: pcgiDoc.content.entity[0]._id,
 			extra_trip_id: pcgiDoc.content.entity[0].vehicle.trip?.extraTripId,
-			latitude: pcgiDoc.content.entity[0].vehicle.position.latitude,
-			longitude: pcgiDoc.content.entity[0].vehicle.position.longitude,
 			odometer: pcgiDoc.content.entity[0].vehicle.position.odometer,
 			pattern_id: pcgiDoc.content.entity[0].vehicle.trip?.patternId,
+			position: {
+				geohash: encode(pcgiDoc.content.entity[0].vehicle.position.latitude, pcgiDoc.content.entity[0].vehicle.position.longitude),
+				h3: latLngToCell(pcgiDoc.content.entity[0].vehicle.position.latitude, pcgiDoc.content.entity[0].vehicle.position.longitude, 15),
+				latitude: pcgiDoc.content.entity[0].vehicle.position.latitude,
+				longitude: pcgiDoc.content.entity[0].vehicle.position.longitude,
+			},
 			received_at: Dates.fromUnixTimestamp(pcgiDoc.millis).unix_timestamp,
 			stop_id: pcgiDoc.content.entity[0].vehicle.stopId,
 			trigger_activity: pcgiDoc.content.entity[0].vehicle.trigger.activity,

--- a/modules/replicator/packages/parse/src/parse-vehicle-event.ts
+++ b/modules/replicator/packages/parse/src/parse-vehicle-event.ts
@@ -18,6 +18,8 @@ export function parseVehicleEvent(pcgiDoc: any): null | SimplifiedVehicleEvent {
 			driver_id: pcgiDoc.content.entity[0].vehicle.vehicle.driverId,
 			event_id: pcgiDoc.content.entity[0]._id,
 			extra_trip_id: pcgiDoc.content.entity[0].vehicle.trip?.extraTripId,
+			latitude: pcgiDoc.content.entity[0].vehicle.position.latitude,
+			longitude: pcgiDoc.content.entity[0].vehicle.position.longitude,
 			odometer: pcgiDoc.content.entity[0].vehicle.position.odometer,
 			pattern_id: pcgiDoc.content.entity[0].vehicle.trip?.patternId,
 			position: {

--- a/packages/types/src/_common/index.ts
+++ b/packages/types/src/_common/index.ts
@@ -4,6 +4,7 @@ export * from '@/_common/environment.js';
 export * from '@/_common/fastify.js';
 export * from '@/_common/mongo.js';
 export * from '@/_common/operational-date.js';
+export * from '@/_common/position.js';
 export * from '@/_common/status.js';
 export * from '@/_common/status.js';
 export * from '@/_common/unix-timestamp.js';

--- a/packages/types/src/_common/position.ts
+++ b/packages/types/src/_common/position.ts
@@ -1,0 +1,10 @@
+import z from 'zod';
+
+/* * */
+
+export const PositionSchema = z.object({
+	geohash: z.string(),
+	h3: z.string(),
+	latitude: z.number(),
+	longitude: z.number(),
+});

--- a/packages/types/src/vehicle-events/simplified-vehicle-event.ts
+++ b/packages/types/src/vehicle-events/simplified-vehicle-event.ts
@@ -1,6 +1,7 @@
 /* * */
 
 import { DocumentSchema } from '@/_common/document.js';
+import { PositionSchema } from '@/_common/position.js';
 import { UnixTimeStampSchema } from '@/_common/unix-timestamp.js';
 import { z } from 'zod';
 
@@ -16,12 +17,7 @@ export const SimplifiedVehicleEventSchema = DocumentSchema
 		extra_trip_id: z.string().nullish(),
 		odometer: z.number(),
 		pattern_id: z.string(),
-		position: z.object({
-			geohash: z.string(),
-			h3: z.string(),
-			latitude: z.number(),
-			longitude: z.number(),
-		}),
+		position: PositionSchema,
 		received_at: UnixTimeStampSchema,
 		stop_id: z.string(),
 		trigger_activity: z.string(),

--- a/packages/types/src/vehicle-events/simplified-vehicle-event.ts
+++ b/packages/types/src/vehicle-events/simplified-vehicle-event.ts
@@ -10,13 +10,18 @@ export const SimplifiedVehicleEventSchema = DocumentSchema
 	.omit({ is_locked: true })
 	.extend({
 		agency_id: z.string(),
+		current_status: z.enum(['INCOMING_AT', 'STOPPED_AT', 'IN_TRANSIT_TO']),
 		driver_id: z.string(),
 		event_id: z.string(),
 		extra_trip_id: z.string().nullish(),
-		latitude: z.number(),
-		longitude: z.number(),
 		odometer: z.number(),
 		pattern_id: z.string(),
+		position: z.object({
+			geohash: z.string(),
+			h3: z.string(),
+			latitude: z.number(),
+			longitude: z.number(),
+		}),
 		received_at: UnixTimeStampSchema,
 		stop_id: z.string(),
 		trigger_activity: z.string(),

--- a/packages/types/src/vehicle-events/simplified-vehicle-event.ts
+++ b/packages/types/src/vehicle-events/simplified-vehicle-event.ts
@@ -15,6 +15,8 @@ export const SimplifiedVehicleEventSchema = DocumentSchema
 		driver_id: z.string(),
 		event_id: z.string(),
 		extra_trip_id: z.string().nullish(),
+		latitude: z.number(),
+		longitude: z.number(),
 		odometer: z.number(),
 		pattern_id: z.string(),
 		position: PositionSchema,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces geospatial enrichment and status to vehicle events.
> 
> - Parser now sets `current_status` and computes `position` with `geohash`, `h3` (res 15), and lat/lon via `h3-js` and `ngeohash`
> - Adds `PositionSchema` and updates `SimplifiedVehicleEventSchema` to include `current_status` and `position`; exports `position` from `_common/index`
> - Adds `h3-js`, `ngeohash`, and `@types/ngeohash` dependencies; minor dependency reorder in stream package.json
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f67cdaa642909e62c21578e7af7e0e720bbc417. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->