### PR TITLE
Fix: Alerts - Automatic Texts

### DIFF
--- a/modules/alerts/apps/frontend/src/components/create/AlertCreate.context.tsx
+++ b/modules/alerts/apps/frontend/src/components/create/AlertCreate.context.tsx
@@ -120,21 +120,19 @@ export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
 	]);
 
 	useEffect(() => {
-		(async () => {
-			if (!form.getValues().cause || !form.getValues().effect || !form.getValues().reference_type || !form.getValues().references?.length) return;
-			const alertTemplating = await describeAlert({
-				cause: form.getValues().cause,
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				data: selectedReferencesData as any[],
-				effect: form.getValues().effect,
-				reference_type: form.getValues().reference_type,
-				references: form.getValues().references ?? [],
-				type: form.getValues().reference_type,
-			});
-			if (!alertTemplating) return;
-			form.setFieldValue('description', alertTemplating.description.pt);
-			form.setFieldValue('title', alertTemplating.title.pt);
-		})();
+		if (!form.getValues().cause || !form.getValues().effect || !form.getValues().reference_type || !form.getValues().references?.length) return;
+		const alertTemplating = describeAlert({
+			cause: form.getValues().cause,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			data: selectedReferencesData as any[],
+			effect: form.getValues().effect,
+			reference_type: form.getValues().reference_type,
+			references: form.getValues().references ?? [],
+			type: form.getValues().reference_type,
+		});
+		if (!alertTemplating) return;
+		form.setFieldValue('description', alertTemplating.description.pt);
+		form.setFieldValue('title', alertTemplating.title.pt);
 	}, [
 		selectedReferencesData,
 		form.getValues().cause,

--- a/modules/alerts/apps/frontend/src/components/create/AlertCreate.context.tsx
+++ b/modules/alerts/apps/frontend/src/components/create/AlertCreate.context.tsx
@@ -6,7 +6,7 @@ import { type Line, type Stop } from '@carrismetropolitana/api-types/network';
 import { API_ROUTES, PAGE_ROUTES } from '@tmlmobilidade/consts';
 import { Dates } from '@tmlmobilidade/dates';
 import { describeAlert } from '@tmlmobilidade/go-alerts-pckg-describe';
-import { type Alert, alertCauseEffectReferenceTypeMap, type CreateAlertDto, CreateAlertSchema, PermissionCatalog, RideNormalized } from '@tmlmobilidade/types';
+import { Agency, type Alert, alertCauseEffectReferenceTypeMap, type CreateAlertDto, CreateAlertSchema, PermissionCatalog, RideNormalized } from '@tmlmobilidade/types';
 import { type CreateContextStateTemplate, keepUrlParams, useDataAgencies, type UseFormReturnType, useHandleUpdate, useMeContext, useMultiStep, type UseMultiStepReturnType, useTypicalForm } from '@tmlmobilidade/ui';
 import { fetchData } from '@tmlmobilidade/utils';
 import { useRouter } from 'next/navigation';
@@ -47,7 +47,7 @@ export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
 
 	const meContext = useMeContext();
 
-	const [selectedReferencesData, setSelectedReferencesData] = useState<RideNormalized[] | { id: string, long_name: string, short_name: string }[] | { id: string, name: string }[]>([]);
+	const [selectedReferencesData, setSelectedReferencesData] = useState<RideNormalized[] | { display_name: string, id: string, name: string }[] | { id: string, long_name: string, short_name: string }[]>([]);
 
 	//
 	// B. Fetch data
@@ -120,14 +120,15 @@ export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
 	]);
 
 	useEffect(() => {
-		if (!form.getValues().cause || !form.getValues().effect || !form.getValues().reference_type || !form.getValues().references?.length) return;
+		if (!form.getValues().cause || !form.getValues().effect || !form.getValues().reference_type || !form.getValues().references) return;
+		const references = form.getValues().references;
 		const alertTemplating = describeAlert({
 			cause: form.getValues().cause,
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			data: selectedReferencesData as any[],
 			effect: form.getValues().effect,
 			reference_type: form.getValues().reference_type,
-			references: form.getValues().references ?? [],
+			references: references,
 			type: form.getValues().reference_type,
 		});
 		if (!alertTemplating) return;
@@ -138,7 +139,7 @@ export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
 		form.getValues().cause,
 		form.getValues().effect,
 		form.getValues().reference_type,
-		form.getValues().references?.length,
+		form.getValues().references,
 	]);
 
 	useEffect(() => {
@@ -200,6 +201,13 @@ export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
 			if (!form.getValues().references?.length) return setSelectedReferencesData([]);
 			// Get a list of unique parent_ids
 			const parentIds = form.getValues().references.map(reference => reference.parent_id);
+			// Fetch data for agencies
+			if (form.getValues().reference_type === 'agency') {
+				const response = await fetch('https://api.carrismetropolitana.pt/v2/agencies'); // ! THIS NEEDS TO BE REPLACED WITH THE CORRECT API URL
+				const agenciesData = await response.json() as Agency[];
+				const result: Agency[] = agenciesData.filter(agency => parentIds.includes(agency._id));
+				setSelectedReferencesData(result.map(agency => ({ display_name: agency.name, id: agency._id, name: agency.name })));
+			}
 			// Fetch data for lines
 			if (form.getValues().reference_type === 'lines') {
 				const response = await fetch('https://api.carrismetropolitana.pt/v2/lines');
@@ -227,7 +235,7 @@ export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
 		})();
 	}, [
 		form.getValues().reference_type,
-		form.getValues().references?.length,
+		form.getValues().references,
 	]);
 
 	const { action: handleCreate, isLoading: isCreating } = useHandleUpdate({

--- a/modules/alerts/apps/frontend/src/components/create/AlertCreate.context.tsx
+++ b/modules/alerts/apps/frontend/src/components/create/AlertCreate.context.tsx
@@ -35,6 +35,25 @@ export function useAlertCreateContext() {
 	return context;
 }
 
+interface AgencyData {
+	display_name: string
+	id: string
+	name: string
+}
+
+interface StopData {
+	id: string
+	lines: LineData[]
+	long_name: string
+}
+
+interface LineData {
+	id: string
+	long_name: string
+	short_name: string
+	stops: StopData[]
+}
+
 /* * */
 
 export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
@@ -47,7 +66,7 @@ export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
 
 	const meContext = useMeContext();
 
-	const [selectedReferencesData, setSelectedReferencesData] = useState<RideNormalized[] | { display_name: string, id: string, name: string }[] | { id: string, long_name: string, short_name: string }[]>([]);
+	const [selectedReferencesData, setSelectedReferencesData] = useState<AgencyData[] | LineData[] | RideNormalized[] | StopData[]>([]);
 
 	//
 	// B. Fetch data
@@ -208,19 +227,111 @@ export const AlertCreateContextProvider = ({ children }: PropsWithChildren) => {
 				const result: Agency[] = agenciesData.filter(agency => parentIds.includes(agency._id));
 				setSelectedReferencesData(result.map(agency => ({ display_name: agency.name, id: agency._id, name: agency.name })));
 			}
+
 			// Fetch data for lines
 			if (form.getValues().reference_type === 'lines') {
 				const response = await fetch('https://api.carrismetropolitana.pt/v2/lines');
 				const linesData = await response.json() as Line[];
 				const result: Line[] = linesData.filter(line => parentIds.includes(line.id));
-				setSelectedReferencesData(result);
+
+				// Get all unique child_ids (stop IDs) from references
+				const allChildIds = form.getValues().references
+					.filter(ref => parentIds.includes(ref.parent_id))
+					.flatMap(ref => ref.child_ids);
+				const uniqueChildIds = [...new Set(allChildIds)];
+
+				// Fetch stops data if there are child_ids
+				const stopsDataMap = new Map<string, Stop>();
+				if (uniqueChildIds.length > 0) {
+					const stopsResponse = await fetch('https://api.carrismetropolitana.pt/v2/stops');
+					const stopsData = await stopsResponse.json() as Stop[];
+					stopsData.filter(stop => uniqueChildIds.includes(stop.id)).forEach((stop) => {
+						stopsDataMap.set(stop.id, stop);
+					});
+				}
+
+				setSelectedReferencesData(result.map((line) => {
+					// Get child_ids for this specific line
+					const lineReference = form.getValues().references.find(ref => ref.parent_id === line.id);
+					const lineChildIds = lineReference?.child_ids ?? [];
+
+					// Map child_ids to StopData
+					const stops: StopData[] = lineChildIds
+						.map(stopId => stopsDataMap.get(stopId))
+						.filter((stop): stop is Stop => stop !== undefined)
+						.map(stop => ({
+							id: stop.id,
+							lines: [],
+							long_name: stop.long_name,
+						}));
+
+					return {
+						id: line.id,
+						long_name: line.long_name,
+						short_name: line.short_name,
+						stops,
+					};
+				}));
 			}
 			// Fetch data for stops
 			if (form.getValues().reference_type === 'stops') {
 				const response = await fetch('https://api.carrismetropolitana.pt/v2/stops');
 				const stopsData = await response.json() as Stop[];
 				const result: Stop[] = stopsData.filter(stop => parentIds.includes(stop.id));
-				setSelectedReferencesData(result);
+
+				const linesResponse = await fetch('https://api.carrismetropolitana.pt/v2/lines');
+				const linesData = await linesResponse.json() as Line[];
+				const selectedLines = linesData.filter(line => result.some(stop => stop.line_ids.includes(line.id)));
+
+				// Get all unique child_ids (stop IDs) from references
+				const allChildIds = form.getValues().references
+					.filter(ref => parentIds.includes(ref.parent_id))
+					.flatMap(ref => ref.child_ids);
+				const uniqueChildIds = [...new Set(allChildIds)];
+
+				// Fetch stops data if there are child_ids
+				const childStopsDataMap = new Map<string, Stop>();
+				if (uniqueChildIds.length > 0) {
+					const childStopsResponse = await fetch('https://api.carrismetropolitana.pt/v2/stops');
+					const childStopsData = await childStopsResponse.json() as Stop[];
+					childStopsData.filter(stop => uniqueChildIds.includes(stop.id)).forEach((stop) => {
+						childStopsDataMap.set(stop.id, stop);
+					});
+				}
+
+				setSelectedReferencesData(result.map((stop) => {
+					// Get child_ids for this specific stop
+					const stopReference = form.getValues().references.find(ref => ref.parent_id === stop.id);
+					const stopChildIds = stopReference?.child_ids ?? [];
+
+					// For each line associated with this stop, populate stops from child_ids
+					const linesWithStops = selectedLines
+						.filter(line => stop.line_ids.includes(line.id))
+						.map((line) => {
+							// Get stops that are child_ids and belong to this line
+							const lineStops: StopData[] = stopChildIds
+								.map(stopId => childStopsDataMap.get(stopId))
+								.filter((childStop): childStop is Stop => childStop !== undefined && childStop.line_ids.includes(line.id))
+								.map(childStop => ({
+									id: childStop.id,
+									lines: [],
+									long_name: childStop.long_name,
+								}));
+
+							return {
+								id: line.id,
+								long_name: line.long_name,
+								short_name: line.short_name,
+								stops: lineStops,
+							};
+						});
+
+					return {
+						id: stop.id,
+						lines: linesWithStops,
+						long_name: stop.long_name,
+					};
+				}));
 			}
 			// Fetch data for rides
 			if (form.getValues().reference_type === 'rides') {

--- a/modules/alerts/apps/frontend/src/components/create/AlertCreateStepSummary/index.tsx
+++ b/modules/alerts/apps/frontend/src/components/create/AlertCreateStepSummary/index.tsx
@@ -34,15 +34,13 @@ export function AlertCreateStepSummary() {
 			scope: PermissionCatalog.all.alerts.scope,
 			value: alertCreateContext.data.form.getValues().reference_type,
 		});
-		const autoTextsEnabled = alertCreateContext.data.form.getValues().auto_texts;
 		// User can edit texts if they have permission for the agency
-		// and reference type, and auto texts is disabled.
-		return canEditThisAgency && canEditThisReferenceType && !autoTextsEnabled;
+		// and reference type.
+		return canEditThisAgency && canEditThisReferenceType;
 	}, [
 		meContext.data.user?.permissions,
 		alertCreateContext.data.form.getValues().agency_id,
 		alertCreateContext.data.form.getValues().reference_type,
-		alertCreateContext.data.form.getValues().auto_texts,
 	]);
 
 	//

--- a/modules/alerts/apps/frontend/src/components/create/AlertCreateStepSummary/index.tsx
+++ b/modules/alerts/apps/frontend/src/components/create/AlertCreateStepSummary/index.tsx
@@ -4,7 +4,7 @@ import { UploadImage } from '@/components/common/other/UploadImage';
 import { useAlertCreateContext } from '@/components/create/AlertCreate.context';
 import { IconLink } from '@tabler/icons-react';
 import { PermissionCatalog } from '@tmlmobilidade/types';
-import { CoordinatesInput, Grid, HasPermission, Section, Switch, Textarea, TextInput, useMeContext } from '@tmlmobilidade/ui';
+import { CoordinatesInput, Grid, Section, Textarea, TextInput, useMeContext } from '@tmlmobilidade/ui';
 import { useMemo } from 'react';
 
 /* * */
@@ -50,18 +50,6 @@ export function AlertCreateStepSummary() {
 
 	return (
 		<Section gap="md">
-			<HasPermission
-				action={PermissionCatalog.all.alerts.actions.update_texts}
-				resourceKey="agency_ids"
-				scope={PermissionCatalog.all.alerts.scope}
-				value={alertCreateContext.data.form.getValues().agency_id}
-			>
-				<Switch
-					key={alertCreateContext.data.form.key('auto_texts')}
-					label="Textos Automáticos"
-					{...alertCreateContext.data.form.getInputProps('auto_texts', { type: 'checkbox' })}
-				/>
-			</HasPermission>
 			<Grid gap="md">
 				<TextInput
 					key={alertCreateContext.data.form.key('title')}

--- a/modules/alerts/apps/frontend/src/components/detail/AlertDetailSectionTexts/index.tsx
+++ b/modules/alerts/apps/frontend/src/components/detail/AlertDetailSectionTexts/index.tsx
@@ -36,15 +36,13 @@ export function AlertDetailSectionTexts() {
 			scope: PermissionCatalog.all.alerts.scope,
 			value: alertDetailContext.data.alert.reference_type,
 		});
-		const autoTextsEnabled = alertDetailContext.data.form.getValues().auto_texts;
 		// User can edit texts if they have permission for the agency
-		// and reference type, and auto texts is disabled.
-		return canEditThisAgency && canEditThisReferenceType && !autoTextsEnabled;
+		// and reference type.
+		return canEditThisAgency && canEditThisReferenceType;
 	}, [
 		meContext.data.user?.permissions,
 		alertDetailContext.data.alert.agency_id,
 		alertDetailContext.data.alert.reference_type,
-		alertDetailContext.data.form.getValues().auto_texts,
 	]);
 
 	//

--- a/modules/alerts/apps/frontend/src/components/detail/AlertDetailSectionTexts/index.tsx
+++ b/modules/alerts/apps/frontend/src/components/detail/AlertDetailSectionTexts/index.tsx
@@ -6,7 +6,7 @@ import { UploadImage } from '@/components/common/other/UploadImage';
 import { useAlertDetailContext } from '@/components/detail/AlertDetail.context';
 import { IconLink } from '@tabler/icons-react';
 import { PermissionCatalog } from '@tmlmobilidade/types';
-import { Collapsible, CoordinatesInput, Grid, HasPermission, Section, Switch, Textarea, TextInput, useMeContext } from '@tmlmobilidade/ui';
+import { Collapsible, CoordinatesInput, Grid, Section, Textarea, TextInput, useMeContext } from '@tmlmobilidade/ui';
 import { useMemo } from 'react';
 
 /* * */
@@ -56,18 +56,6 @@ export function AlertDetailSectionTexts() {
 			title="Título e Descrição"
 		>
 			<Section gap="md">
-				<HasPermission
-					action={PermissionCatalog.all.alerts.actions.update_texts}
-					resourceKey="agency_ids"
-					scope={PermissionCatalog.all.alerts.scope}
-					value={alertDetailContext.data.alert.agency_id}
-				>
-					<Switch
-						key={alertDetailContext.data.form.key('auto_texts')}
-						label="Textos Automáticos"
-						{...alertDetailContext.data.form.getInputProps('auto_texts', { type: 'checkbox' })}
-					/>
-				</HasPermission>
 				<Grid gap="md">
 					<TextInput
 						key={alertDetailContext.data.form.key('title')}

--- a/modules/alerts/apps/sync-datik/src/index.ts
+++ b/modules/alerts/apps/sync-datik/src/index.ts
@@ -53,7 +53,6 @@ async function main() {
 				active_period_end_date: null,
 				active_period_start_date: undefined,
 				agency_id: '43',
-				auto_texts: true,
 				cause: serviceAlert.alert.cause as CreateAlertDto['cause'],
 				coordinates: null,
 				description: description,

--- a/modules/alerts/helpers/migrate-db/src/index.ts
+++ b/modules/alerts/helpers/migrate-db/src/index.ts
@@ -54,7 +54,6 @@ import { municipalitiesMap } from './municipalities-map.js';
 			const formattedAlert: Alert = {
 				...originalAlert,
 				agency_id: agencyId,
-				auto_texts: false,
 				created_by: 'system',
 				publish_status: parsePublishStatus(originalAlert.publish_status),
 				reference_type: parseReferenceType(originalAlert.reference_type),

--- a/modules/alerts/packages/describe/src/render.ts
+++ b/modules/alerts/packages/describe/src/render.ts
@@ -17,7 +17,7 @@ export interface DescribeAlertReturnType {
 
 /* * */
 
-export async function describeAlert(props: DescribeAlertProps): Promise<DescribeAlertReturnType | undefined> {
+export function describeAlert(props: DescribeAlertProps): DescribeAlertReturnType | undefined {
 	//
 
 	//

--- a/modules/alerts/packages/describe/src/render.ts
+++ b/modules/alerts/packages/describe/src/render.ts
@@ -71,7 +71,6 @@ export function describeAlert(props: DescribeAlertProps): DescribeAlertReturnTyp
 				//
 
 				// Use the templates param builders to get the actual value for each placeholder
-				console.log('HERE PLACEHOLDER KEY =======>', props.reference_type, placeholderKey);
 				const replacementValue = templatePlaceholderReplacements[props.reference_type][placeholderKey](props.data);
 
 				// Replace all occurrences of the placeholder in the string with the actual value

--- a/modules/alerts/packages/describe/src/render.ts
+++ b/modules/alerts/packages/describe/src/render.ts
@@ -25,6 +25,8 @@ export function describeAlert(props: DescribeAlertProps): DescribeAlertReturnTyp
 
 	if (!props.cause || !props.effect || !props.reference_type || !props.references || !props.data) return;
 
+	console.log('HERE PROPS =======>', props);
+
 	//
 	// Setup result object
 

--- a/modules/alerts/packages/describe/src/render.ts
+++ b/modules/alerts/packages/describe/src/render.ts
@@ -36,7 +36,7 @@ export function describeAlert(props: DescribeAlertProps): DescribeAlertReturnTyp
 	//
 	// Detect if the alert is singular or plural based on the reference type
 
-	const isPlural = props.references.length > 1;
+	const pluralKey = props.references.length > 1 ? 'plural' : 'singular';
 
 	//
 	// Build the key to access the templates
@@ -49,23 +49,35 @@ export function describeAlert(props: DescribeAlertProps): DescribeAlertReturnTyp
 	// and replace the placeholders with actual values.
 
 	for (const resultStringKey of Object.keys(result) as (keyof DescribeAlertReturnType)[]) {
+		//
+
 		// Each result string key has several i18n codes to populate
 		for (const i18nCode of Object.keys(result[resultStringKey]) as I18nCodes[]) {
+			//
+
 			// Determine which template string we are populating, and if it is singular or plural.
 			// Even though we might need a plural string, if it does not exist we fallback to the singular one.
 			const templateStringType = alertI18nTemplates[templateKey][resultStringKey];
-			const templateStringCountableVariation = templateStringType[isPlural ? 'plural' : 'singular'] ? templateStringType[isPlural ? 'plural' : 'singular'] : templateStringType.singular;
+			const templateStringCountableVariation = templateStringType[pluralKey] ? templateStringType[pluralKey] : templateStringType.singular;
+
 			// Skip if the template string variation is not defined
 			if (!templateStringCountableVariation) continue;
+
 			// Set the base string from the templates in the result object
 			result[resultStringKey][i18nCode] = templateStringCountableVariation[i18nCode];
+
 			// Each translated string has several placeholders that need to be replaced with actual values.
-			for (const placeholderKey of Object.keys(templatePlaceholderReplacements)) {
-			// Use the templates param builders to get the actual value for each placeholder
-				const replacementValue = templatePlaceholderReplacements[placeholderKey](props.data);
+			for (const placeholderKey of Object.keys(templatePlaceholderReplacements[props.reference_type])) {
+				//
+
+				// Use the templates param builders to get the actual value for each placeholder
+				console.log('HERE PLACEHOLDER KEY =======>', props.reference_type, placeholderKey);
+				const replacementValue = templatePlaceholderReplacements[props.reference_type][placeholderKey](props.data);
+
 				// Replace all occurrences of the placeholder in the string with the actual value
 				result[resultStringKey][i18nCode] = result[resultStringKey][i18nCode].replaceAll(placeholderKey, replacementValue);
 			}
+
 			// Each translated string has several articles that need to be replaced with actual values.
 			for (const articleKey of Object.keys(templateArticlesReplacements)) {
 				// Use the templates param builders to get the actual value for each article

--- a/modules/alerts/packages/describe/src/templates/descriptions.ts
+++ b/modules/alerts/packages/describe/src/templates/descriptions.ts
@@ -152,21 +152,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Devido a um acidente, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido a um acidente, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Devido a um acidente, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido a um acidente, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 		},
 	},
@@ -612,21 +612,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Devido a um evento, foram adicionados novos horários em toda a rede. Consulte o site carrismetropolitana.pt para mais informações.',
+				pt: 'Devido a um evento, foram adicionados novos horários {in_def_f_s} {agency_title}. Consulte o site carrismetropolitana.pt para mais informações.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Devido a um evento, foram adicionados novos horários em toda a rede. Consulte o site carrismetropolitana.pt para mais informações.',
+				pt: 'Devido a um evento, foram adicionados novos horários {in_def_f_s} {agency_title}. Consulte o site carrismetropolitana.pt para mais informações.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Horários adicionais',
+				pt: '{agency_title} | Horários adicionais',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Horários adicionais',
+				pt: '{agency_title} | Horários adicionais',
 			},
 		},
 	},
@@ -888,21 +888,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Devido a um evento, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido a um evento, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Devido a um evento, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido a um evento, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 		},
 	},
@@ -1417,21 +1417,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Devido a atividade policial, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido a atividade policial, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Devido a atividade policial, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido a atividade policial, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 		},
 	},
@@ -1923,21 +1923,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Devido à realização de greve, foram adicionados novos horários em toda a rede. Consulte o site carrismetropolitana.pt para mais informações.',
+				pt: 'Devido à realização de greve, foram adicionados novos horários {in_def_f_s} {agency_title}. Consulte o site carrismetropolitana.pt para mais informações.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Devido à realização de greve, foram adicionados novos horários em toda a rede. Consulte o site carrismetropolitana.pt para mais informações.',
+				pt: 'Devido à realização de greve, foram adicionados novos horários {in_def_f_s} {agency_title}. Consulte o site carrismetropolitana.pt para mais informações.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Horários adicionais',
+				pt: '{agency_title} | Horários adicionais',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Horários adicionais',
+				pt: '{agency_title} | Horários adicionais',
 			},
 		},
 	},
@@ -2061,21 +2061,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Por motivos de greve foi necessário cancelar o serviço em toda a rede. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Por motivos de greve foi necessário cancelar o serviço {in_def_f_s} {agency_title}. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Por motivos de greve foi necessário cancelar o serviço em toda a rede. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Por motivos de greve foi necessário cancelar o serviço {in_def_f_s} {agency_title}. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Serviço cancelado',
+				pt: '{agency_title} | Serviço cancelado',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Serviço cancelado',
+				pt: '{agency_title} | Serviço cancelado',
 			},
 		},
 	},
@@ -2176,21 +2176,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Por motivos de greve, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Por motivos de greve, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Por motivos de greve, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Por motivos de greve, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 		},
 	},
@@ -2291,21 +2291,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Um problema técnico está a impedir o funcionamento normal dos sistemas de localização em tempo real em toda a rede. Lamentamos o incómodo causado enquanto restabelecemos o funcionamento normal.',
+				pt: 'Um problema técnico está a impedir o funcionamento normal dos sistemas de localização em tempo real {in_def_f_s} {agency_title}. Lamentamos o incómodo causado enquanto restabelecemos o funcionamento normal.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Um problema técnico está a impedir o funcionamento normal dos sistemas de localização em tempo real em toda a rede. Lamentamos o incómodo causado enquanto restabelecemos o funcionamento normal.',
+				pt: 'Um problema técnico está a impedir o funcionamento normal dos sistemas de localização em tempo real {in_def_f_s} {agency_title}. Lamentamos o incómodo causado enquanto restabelecemos o funcionamento normal.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Tempo real indisponível',
+				pt: '{agency_title} | Tempo real indisponível',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Tempo real indisponível',
+				pt: '{agency_title} | Tempo real indisponível',
 			},
 		},
 	},
@@ -2360,21 +2360,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Devido a um problema técnico, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido a um problema técnico, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Devido a um problema técnico, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido a um problema técnico, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 		},
 	},
@@ -2521,21 +2521,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Devido ao elevado volume de trânsito, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido ao elevado volume de trânsito, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Devido ao elevado volume de trânsito, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido ao elevado volume de trânsito, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 		},
 	},
@@ -2889,21 +2889,21 @@ export const alertI18nTemplates: Record<AlertCauseEffectReference, TemplateFragm
 		description: {
 			plural: {
 				en: 'not-available',
-				pt: 'Devido às condições metereológicas adversas, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido às condições metereológicas adversas, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Devido às condições metereológicas adversas, verificam-se atrasos significativos em toda a rede. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
+				pt: 'Devido às condições metereológicas adversas, verificam-se atrasos significativos {in_def_f_s} {agency_title}. As viagens não foram canceladas e deverão realizar-se assim que o problema seja resolvido. Lamentamos o incómodo e agradecemos a sua compreensão.',
 			},
 		},
 		title: {
 			plural: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 			singular: {
 				en: 'not-available',
-				pt: 'Toda a rede | Atrasos significativos',
+				pt: '{agency_title} | Atrasos significativos',
 			},
 		},
 	},

--- a/modules/alerts/packages/describe/src/templates/placeholders.ts
+++ b/modules/alerts/packages/describe/src/templates/placeholders.ts
@@ -51,7 +51,6 @@ export const templatePlaceholderReplacements = {
 	 */
 		'{rides_description_pt}': (data: Extract<DescribeAlertProps, { type: 'rides' }>['data']) => {
 		//
-			console.log('HERE RIDES DESCRIPTION PT =======>', data);
 
 			//
 			// Fetch ride details based on the provided ride IDs

--- a/modules/alerts/packages/describe/src/templates/placeholders.ts
+++ b/modules/alerts/packages/describe/src/templates/placeholders.ts
@@ -21,11 +21,40 @@ export const templatePlaceholderReplacements = {
 
 	lines: {
 		/**
-		 * Returns a comma-separated list of line short names in Portuguese.
+		 * Returns a descriptive string for lines in Portuguese, with details about stops when available.
+		 * Groups lines and includes stop information.
 		 */
 		'{lines_description_pt}': (data: Extract<DescribeAlertProps, { type: 'lines' }>['data']) => {
-			const lineShortNames = Array.from(new Set(data.map(ht => ht.short_name) ?? []));
-			return lineShortNames.join(', ');
+		//
+
+			//
+			// Group lines and build prose string in the format:
+			// "linha 1234 nas paragens X, Y e Z" or "linhas 1234, 5678"
+
+			const parts: string[] = [];
+
+			for (const lineData of data) {
+				const lineShortName = lineData.short_name;
+				const stops = lineData.stops ?? [];
+
+				if (stops.length > 0) {
+					const stopNames = stops.map(stop => stop.long_name).filter(Boolean);
+					const stopsPart = stopNames.length > 1
+						? `nas paragens ${stopNames.slice(0, -1).join(', ')} e ${stopNames.slice(-1)}`
+						: `na paragem ${stopNames[0]}`;
+
+					parts.push(`linha ${lineShortName} ${stopsPart}`);
+				}
+				else {
+					parts.push(`linha ${lineShortName}`);
+				}
+			}
+
+			return parts.length > 1
+				? parts.slice(0, -1).join('; ') + ' e ' + parts.slice(-1)
+				: parts[0];
+
+		//
 		},
 
 		/**
@@ -42,9 +71,9 @@ export const templatePlaceholderReplacements = {
 	rides: {
 
 		/**
-	 * Returns a descriptive string for rides in Portuguese, with details about start times and lines.
-	 * Can handle multiple rides and groups them by pattern ID.
-	 */
+		 * Returns a descriptive string for rides in Portuguese, with details about start times and lines.
+		 * Can handle multiple rides and groups them by pattern ID.
+		 */
 		'{rides_description_pt}': (data: Extract<DescribeAlertProps, { type: 'rides' }>['data']) => {
 		//
 
@@ -101,12 +130,44 @@ export const templatePlaceholderReplacements = {
 	},
 
 	stops: {
+		/**
+		 * Returns a descriptive string for stops in Portuguese, with details about lines when available.
+		 * Groups stops and includes line information.
+		 */
 		'{stops_description_pt}': (data: Extract<DescribeAlertProps, { type: 'stops' }>['data']) => {
-			const stopNames = Array.from(new Set(data.map(ht => ht.name) ?? []));
-			return stopNames.join(', ');
+		//
+
+			//
+			// Group stops and build prose string in the format:
+			// "paragem X das linhas 1234, 5678" or "paragens X, Y e Z"
+
+			const parts: string[] = [];
+
+			for (const stopData of data) {
+				const stopName = stopData.long_name;
+				const lines = stopData.lines ?? [];
+
+				if (lines.length > 0) {
+					const lineShortNames = lines.map(line => line.short_name).filter(Boolean);
+					const linesPart = lineShortNames.length > 1
+						? `das linhas ${lineShortNames.slice(0, -1).join(', ')} e ${lineShortNames.slice(-1)}`
+						: `da linha ${lineShortNames[0]}`;
+
+					parts.push(`paragem ${stopName} ${linesPart}`);
+				}
+				else {
+					parts.push(`paragem ${stopName}`);
+				}
+			}
+
+			return parts.length > 1
+				? parts.slice(0, -1).join('; ') + ' e ' + parts.slice(-1)
+				: parts[0];
+
+		//
 		},
 		'{stops_title}': (data: Extract<DescribeAlertProps, { type: 'stops' }>['data']) => {
-			const stopNames = Array.from(new Set(data.map(ht => ht.name).filter(Boolean)));
+			const stopNames = Array.from(new Set(data.map(ht => ht.long_name).filter(Boolean)));
 			return stopNames.length > 1
 				? `paragens ${stopNames.join(', ')}`
 				: `paragem ${stopNames[0]}`;

--- a/modules/alerts/packages/describe/src/templates/placeholders.ts
+++ b/modules/alerts/packages/describe/src/templates/placeholders.ts
@@ -4,89 +4,121 @@
 
 import { type DescribeAlertProps } from '@/types/describe-alert-props.js';
 import { Dates } from '@tmlmobilidade/dates';
-import { type RideNormalized } from '@tmlmobilidade/types';
+import { AlertReferenceType, type RideNormalized } from '@tmlmobilidade/types';
 
 /* * */
 
 export const templatePlaceholderReplacements = {
 
-	/**
-	 * Returns a comma-separated list of line short names in Portuguese.
-	 */
-	'{lines_description_pt}': (data: Extract<DescribeAlertProps, { type: 'lines' }>['data']) => {
-		const lineShortNames = Array.from(new Set(data.map(ht => ht.short_name) ?? []));
-		return lineShortNames.join(', ');
+	agency: {
+		'{agency_description_pt}': (data: Extract<DescribeAlertProps, { type: 'agency' }>['data']) => {
+			const agencyNames = Array.from(new Set(data.map(ht => ht.long_name) ?? []));
+			return agencyNames.join(', ');
+		},
+		'{agency_title}': (data: Extract<DescribeAlertProps, { type: 'agency' }>['data']) => {
+			const agencyNames = Array.from(new Set(data.map(ht => ht.long_name).filter(Boolean)));
+			return agencyNames.length > 1
+				? `agências ${agencyNames.join(', ')}`
+				: `agência ${agencyNames[0]}`;
+		},
 	},
 
-	/**
-	 * Returns a string indicating the line or lines affected in Portuguese.
-	 */
-	'{lines_title}': (data: Extract<DescribeAlertProps, { type: 'lines' }>['data']) => {
-		const lineShortNames = Array.from(new Set(data.map(ht => ht.short_name)));
-		return lineShortNames.length > 1
-			? `linhas ${lineShortNames.join(', ')}`
-			: `linha ${lineShortNames[0]}`;
+	lines: {
+		/**
+		 * Returns a comma-separated list of line short names in Portuguese.
+		 */
+		'{lines_description_pt}': (data: Extract<DescribeAlertProps, { type: 'lines' }>['data']) => {
+			const lineShortNames = Array.from(new Set(data.map(ht => ht.short_name) ?? []));
+			return lineShortNames.join(', ');
+		},
+
+		/**
+		 * Returns a string indicating the line or lines affected in Portuguese.
+		 */
+		'{lines_title}': (data: Extract<DescribeAlertProps, { type: 'lines' }>['data']) => {
+			const lineShortNames = Array.from(new Set(data.map(ht => ht.short_name).filter(Boolean)));
+			return lineShortNames.length > 1
+				? `linhas ${lineShortNames.join(', ')}`
+				: `linha ${lineShortNames[0]}`;
+		},
 	},
 
-	/**
+	rides: {
+
+		/**
 	 * Returns a descriptive string for rides in Portuguese, with details about start times and lines.
 	 * Can handle multiple rides and groups them by pattern ID.
 	 */
-	'{rides_description_pt}': (data: Extract<DescribeAlertProps, { type: 'rides' }>['data']) => {
+		'{rides_description_pt}': (data: Extract<DescribeAlertProps, { type: 'rides' }>['data']) => {
 		//
+			console.log('HERE RIDES DESCRIPTION PT =======>', data);
 
-		//
-		// Fetch ride details based on the provided ride IDs
-		// and the corresponding HashedTrip objects
+			//
+			// Fetch ride details based on the provided ride IDs
+			// and the corresponding HashedTrip objects
 
-		const patternGroups: Record<RideNormalized['pattern_id'], RideNormalized[]> = {};
+			const patternGroups: Record<RideNormalized['pattern_id'], RideNormalized[]> = {};
 
-		for (const rideData of data) {
-			if (!patternGroups[rideData.pattern_id]) {
-				patternGroups[rideData.pattern_id] = [];
+			for (const rideData of data) {
+				if (!patternGroups[rideData.pattern_id]) {
+					patternGroups[rideData.pattern_id] = [];
+				}
+				patternGroups[rideData.pattern_id].push(rideData);
 			}
-			patternGroups[rideData.pattern_id].push(rideData);
-		}
+
+			//
+			// Now that we have the groups, build the prose string in the format:
+			// "Viagem das 08h00, 09h00 e 10h00 da linha 1234 com destino a Lisboa"
+
+			const parts: string[] = [];
+
+			for (const [, group] of Object.entries(patternGroups).sort()) {
+				const rideStartTimes = group
+					.sort((a, b) => a.start_time_scheduled - b.start_time_scheduled)
+					.map(ride => Dates.fromUnixTimestamp(ride.start_time_scheduled).setZone('Europe/Lisbon', 'rebase_utc').toFormat('HH:mm'));
+
+				const lineShortNames = Array.from(new Set(group.map(ht => ht.line_id)));
+				const linePart = lineShortNames.length > 1
+					? `das linhas ${lineShortNames.join(', ')}`
+					: `da linha ${lineShortNames[0]} com destino a ${group[0].headsign}`;
+
+				const ridesPart = rideStartTimes.length > 1
+					? `viagens das ${rideStartTimes.slice(0, -1).join(', ')} e ${rideStartTimes.slice(-1)}`
+					: `viagem das ${rideStartTimes[0]}`;
+
+				parts.push(`${ridesPart} ${linePart}`);
+			}
+
+			return parts.length > 1
+				? parts.slice(0, -1).join('; ') + ' e ' + parts.slice(-1)
+				: parts[0];
 
 		//
-		// Now that we have the groups, build the prose string in the format:
-		// "Viagem das 08h00, 09h00 e 10h00 da linha 1234 com destino a Lisboa"
+		},
 
-		const parts: string[] = [];
-
-		for (const [, group] of Object.entries(patternGroups).sort()) {
-			const rideStartTimes = group
-				.sort((a, b) => a.start_time_scheduled - b.start_time_scheduled)
-				.map(ride => Dates.fromUnixTimestamp(ride.start_time_scheduled).setZone('Europe/Lisbon', 'rebase_utc').toFormat('HH:mm'));
-
-			const lineShortNames = Array.from(new Set(group.map(ht => ht.line_id)));
-			const linePart = lineShortNames.length > 1
-				? `das linhas ${lineShortNames.join(', ')}`
-				: `da linha ${lineShortNames[0]} com destino a ${group[0].headsign}`;
-
-			const ridesPart = rideStartTimes.length > 1
-				? `viagens das ${rideStartTimes.slice(0, -1).join(', ')} e ${rideStartTimes.slice(-1)}`
-				: `viagem das ${rideStartTimes[0]}`;
-
-			parts.push(`${ridesPart} ${linePart}`);
-		}
-
-		return parts.length > 1
-			? parts.slice(0, -1).join('; ') + ' e ' + parts.slice(-1)
-			: parts[0];
-
-		//
-	},
-
-	/**
+		/**
 	 * Returns a comma-separated list of line IDs for rides.
 	 */
-	'{rides_title}': (data: Extract<DescribeAlertProps, { type: 'rides' }>['data']) => {
-		const lineShortNames = Array.from(new Set(data.map(ht => ht.line_id) ?? [])).sort();
-		return lineShortNames.join(', ');
+		'{rides_title}': (data: Extract<DescribeAlertProps, { type: 'rides' }>['data']) => {
+			const lineShortNames = Array.from(new Set(data.map(ht => ht.line_id) ?? [])).sort();
+			return lineShortNames.join(', ');
+		},
 	},
 
-} as const satisfies Record<string, (data: DescribeAlertProps['data']) => string>;
+	stops: {
+		'{stops_description_pt}': (data: Extract<DescribeAlertProps, { type: 'stops' }>['data']) => {
+			const stopNames = Array.from(new Set(data.map(ht => ht.name) ?? []));
+			return stopNames.join(', ');
+		},
+		'{stops_title}': (data: Extract<DescribeAlertProps, { type: 'stops' }>['data']) => {
+			const stopNames = Array.from(new Set(data.map(ht => ht.name).filter(Boolean)));
+			return stopNames.length > 1
+				? `paragens ${stopNames.join(', ')}`
+				: `paragem ${stopNames[0]}`;
+		},
+	},
+
+} as const satisfies Record<AlertReferenceType, Record<string, (data: DescribeAlertProps['data']) => string>>;
 
 /* * */
 

--- a/modules/alerts/packages/describe/src/templates/placeholders.ts
+++ b/modules/alerts/packages/describe/src/templates/placeholders.ts
@@ -11,12 +11,8 @@ import { AlertReferenceType, type RideNormalized } from '@tmlmobilidade/types';
 export const templatePlaceholderReplacements = {
 
 	agency: {
-		'{agency_description_pt}': (data: Extract<DescribeAlertProps, { type: 'agency' }>['data']) => {
-			const agencyNames = Array.from(new Set(data.map(ht => ht.long_name) ?? []));
-			return agencyNames.join(', ');
-		},
 		'{agency_title}': (data: Extract<DescribeAlertProps, { type: 'agency' }>['data']) => {
-			const agencyNames = Array.from(new Set(data.map(ht => ht.long_name).filter(Boolean)));
+			const agencyNames = Array.from(new Set(data.map(agency => agency.display_name).filter(Boolean)));
 			return agencyNames.length > 1
 				? `agências ${agencyNames.join(', ')}`
 				: `agência ${agencyNames[0]}`;

--- a/modules/alerts/packages/describe/src/types/describe-alert-props.ts
+++ b/modules/alerts/packages/describe/src/types/describe-alert-props.ts
@@ -26,6 +26,10 @@ const DescribeAlertPropsLinesSchema = DescribeAlertPropsBaseSchema.extend({
 		id: z.string(),
 		long_name: z.string(),
 		short_name: z.string(),
+		stops: z.array(z.object({
+			id: z.string(),
+			long_name: z.string(),
+		})),
 	})).default([]),
 	type: z.literal('lines'),
 });
@@ -38,7 +42,12 @@ const DescribeAlertPropsRidesSchema = DescribeAlertPropsBaseSchema.extend({
 const DescribeAlertPropsStopsSchema = DescribeAlertPropsBaseSchema.extend({
 	data: z.array(z.object({
 		id: z.string(),
-		name: z.string(),
+		lines: z.array(z.object({
+			id: z.string(),
+			long_name: z.string(),
+			short_name: z.string(),
+		})),
+		long_name: z.string(),
 	})).default([]),
 	type: z.literal('stops'),
 });

--- a/modules/alerts/packages/describe/src/types/describe-alert-props.ts
+++ b/modules/alerts/packages/describe/src/types/describe-alert-props.ts
@@ -14,9 +14,9 @@ export const DescribeAlertPropsBaseSchema = z.object({
 
 const DescribeAlertPropsAgencySchema = DescribeAlertPropsBaseSchema.extend({
 	data: z.array(z.object({
+		display_name: z.string(),
 		id: z.string(),
-		long_name: z.string(),
-		short_name: z.string(),
+		name: z.string(),
 	})).default([]),
 	type: z.literal('agency'),
 });

--- a/packages/types/src/alerts/alert.ts
+++ b/packages/types/src/alerts/alert.ts
@@ -14,7 +14,6 @@ export const AlertSchema = DocumentSchema.extend({
 	active_period_end_date: UnixTimeStampSchema.nullable().default(null),
 	active_period_start_date: UnixTimeStampSchema,
 	agency_id: z.string(),
-	auto_texts: z.boolean().default(true),
 	cause: AlertCauseSchema,
 	coordinates: z.tuple([z.number(), z.number()]).nullable().default(null),
 	description: z.string(),


### PR DESCRIPTION
## Summary

This PR removes the `auto_texts` toggle feature and makes automatic text generation always enabled for alerts. Additionally, it significantly improves the data structure and template system to generate more accurate and context-aware alert descriptions.

## Changes

### 🔄 Always-Enabled Automatic Text Generation
- Removed `auto_texts` field from Alert schema and all related code
- Removed "Textos Automáticos" toggle switches from create and detail components
- Automatic text generation now always runs when alert properties change
- Users can now always edit generated texts (subject to permissions)

### 📊 Enhanced Data Fetching & Structure
- **Agency support**: Added fetching and data structure for agency references
- **Lines with stops**: Enhanced line data to include associated stops (via `child_ids`)
- **Stops with lines**: Enhanced stop data to include associated lines
- Improved nested data relationships for more accurate text generation

### 🏗️ Refactored Placeholder System
- Restructured placeholder replacements to be organized by reference type (`agency`, `lines`, `rides`, `stops`)
- Improved placeholder functions to handle nested data structures
- Better support for plural/singular variations

### 📝 Template Improvements
- Updated agency-related templates to use dynamic `{agency_title}` placeholder instead of hardcoded "Toda a rede"
- Templates now properly reflect the specific agency/network affected
- Improved descriptions with better context about lines, stops, and their relationships

### ⚡ Performance & Code Quality
- Changed `describeAlert` from async to synchronous (no longer needs async data fetching)
- Improved type safety with better TypeScript types for data structures
- Cleaner dependency tracking in useEffect hooks

## Technical Details

- **Data Structure Changes**: Lines now include `stops` array, stops include `lines` array, agencies have `display_name` and `name` fields
- **Placeholder Organization**: Placeholders are now scoped by reference type: `templatePlaceholderReplacements[reference_type][placeholder]`
- **Template Updates**: All agency-related templates updated to use `{agency_title}` and `{in_def_f_s} {agency_title}` placeholders

## Migration Notes

- Existing alerts with `auto_texts: false` will continue to work, but the field is no longer used
- Database migration may be needed to remove the `auto_texts` field (not included in this PR)
- Sync and migration helpers no longer set `auto_texts` values