### PR TITLE
Refactor service alert structure to standardize image property naming from localizedImage to localized_image for consistency across the codebase.

### DIFF
--- a/modules/alerts/apps/api/src/utils/service-alert-parser.ts
+++ b/modules/alerts/apps/api/src/utils/service-alert-parser.ts
@@ -109,8 +109,9 @@ async function parseServiceAlert(alert: Alert, lines: Line[]): Promise<ServiceAl
 				],
 			},
 			image: file ? {
-				localizedImage: [
+				localized_image: [
 					{
+						language: 'pt-PT',
 						media_type: file.type ?? 'image/png',
 						url: file.url ?? '',
 					},

--- a/packages/types/src/gtfs/service-alert.ts
+++ b/packages/types/src/gtfs/service-alert.ts
@@ -10,7 +10,7 @@ export interface ServiceAlertExtended extends Omit<ServiceAlert, 'cause' | 'effe
 	effect: string
 	file_id?: string
 	image?: {
-		localizedImage: {
+		localized_image: {
 			language?: string
 			media_type: string
 			url: string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename-only change that updates the service alert image payload shape and its TypeScript type; main risk is breaking any downstream consumers still expecting `localizedImage`.
> 
> **Overview**
> Standardizes the service-alert image payload shape by renaming `image.localizedImage` to `image.localized_image` in the API `parseServiceAlert` output.
> 
> Updates the shared `ServiceAlertExtended` type to match the new field name (including setting the image item language to `pt-PT`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0cd3b4c96eb72268d2eb9c7cceafbae91814139. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->