### PR TITLE
Clickhouse interface

### DIFF
--- a/packages/clickhouse/eslint.config.mjs
+++ b/packages/clickhouse/eslint.config.mjs
@@ -1,9 +1,0 @@
-/* * */
-
-import { node } from '@tmlmobilidade/eslint'
-
-/* * */
-
-export default [
-  node
-]

--- a/packages/clickhouse/eslint.config.mjs
+++ b/packages/clickhouse/eslint.config.mjs
@@ -1,0 +1,9 @@
+/* * */
+
+import { node } from '@tmlmobilidade/eslint'
+
+/* * */
+
+export default [
+  node
+]

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -1,0 +1,48 @@
+{
+	"name": "@tmlmobilidade/clickhouse",
+	"version": "1.0.0",
+	"author": {
+		"email": "iso@tmlmobilidade.pt",
+		"name": "TML-ISO"
+	},
+	"license": "AGPL-3.0-or-later",
+	"homepage": "https://go.tmlmobilidade.pt",
+	"bugs": {
+		"url": "https://github.com/tmlmobilidade/go/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tmlmobilidade/go.git"
+	},
+	"keywords": [
+		"public transit",
+		"tml",
+		"transportes metropolitanos de lisboa",
+		"go"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"type": "module",
+	"files": ["dist"],
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "tsc && resolve-tspaths",
+		"lint": "eslint ./src/ && tsc --noEmit",
+		"lint:fix": "eslint ./src/ --fix",
+		"watch": "tsc-watch --onSuccess 'resolve-tspaths'"
+	},
+	"dependencies": {
+		"@clickhouse/client": "1.17.0",
+		"@tmlmobilidade/logger": "*",
+		"@tmlmobilidade/utils": "*"
+	},
+	"devDependencies": {
+		"@tmlmobilidade/tsconfig": "*",
+		"@types/node": "25.3.0",
+		"resolve-tspaths": "0.8.23",
+		"tsc-watch": "7.2.0",
+		"typescript": "5.9.3"
+	}
+}

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -1,24 +1,22 @@
 /* * */
 
-import { AsyncSingletonProxy } from '@tmlmobilidade/utils';
 import { ClickHouseClient, createClient } from '@clickhouse/client';
 import { Logger } from '@tmlmobilidade/logger';
+import { AsyncSingletonProxy } from '@tmlmobilidade/utils';
+import { readFile } from 'fs/promises';
+
 import { ClickHouseColumn } from './types.js';
 import { isSafeIdentifier } from './utils.js';
-import { readFile } from 'fs/promises';
 
 /* * */
 
-
 class ClickhouseService {
-
-	private client: ClickHouseClient;
 	private static _instance: ClickhouseService;
+	private client: ClickHouseClient;
 
 	private constructor() {
-
 		// Check missing environment variables
-		const missingEnvVars = [ 'CLICKHOUSE_DATABASE', 'CLICKHOUSE_URI'].filter(envVar => !process.env[envVar]);
+		const missingEnvVars = ['CLICKHOUSE_DATABASE', 'CLICKHOUSE_URI'].filter(envVar => !process.env[envVar]);
 		if (missingEnvVars.length > 0) {
 			throw new Error(`Missing ClickHouse environment variables: ${missingEnvVars.join(', ')}`);
 		}
@@ -47,7 +45,6 @@ class ClickhouseService {
 	 * @param orderBy The ORDER BY clause for the table (default: tuple())
 	 */
 	public async createTable<T>(table: string, schema: ClickHouseColumn<T>[], engine = 'MergeTree', orderBy = 'tuple()') {
-
 		// Validate the table name
 		if (!isSafeIdentifier(table)) {
 			throw new Error(`CLICKHOUSE [${table}]: Unsafe table name provided.`);
@@ -91,7 +88,6 @@ class ClickhouseService {
 	 * @param table The name of the table to delete
 	 */
 	public async deleteTable(table: string) {
-
 		// Validate the table name
 		if (!isSafeIdentifier(table)) {
 			throw new Error(`CLICKHOUSE [${table}]: Unsafe table name provided.`);
@@ -105,7 +101,6 @@ class ClickhouseService {
 			throw error;
 		}
 	}
-
 
 	/**
 	 * Gets a table in ClickHouse if it exists.
@@ -136,13 +131,12 @@ class ClickhouseService {
 	 * @param params Optional key-value substitutions applied to the query (replaces {key} placeholders)
 	 * @returns Query result rows typed as T
 	 */
-	public async queryFromFile<T>(filePath: string, params?: Record<string, string | number>): Promise<T[]> {
+	public async queryFromFile<T>(filePath: string, params?: Record<string, number | string>): Promise<T[]> {
 		let sql: string;
 
 		try {
 			sql = await readFile(filePath, { encoding: 'utf-8' });
-		}
-		catch (error) {
+		} catch (error) {
 			Logger.error(`CLICKHOUSE: Error reading SQL file "${filePath}": ${(error as Error).message}`);
 			throw error;
 		}
@@ -156,10 +150,9 @@ class ClickhouseService {
 		}
 
 		try {
-			const result = await this.client.query({ query: sql, format: 'JSONEachRow' });
+			const result = await this.client.query({ format: 'JSONEachRow', query: sql });
 			return result.json<T>();
-		}
-		catch (error) {
+		} catch (error) {
 			Logger.error(`CLICKHOUSE: Error @ queryFromFile() "${filePath}": ${(error as Error).message}`);
 			throw error;
 		}

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -107,7 +107,7 @@ class ClickhouseService {
 	 *
 	 * @returns The ClickHouse client
 	 */
-	public getClient(): ClickHouseClient {
+	public async getClient(): Promise<ClickHouseClient> {
 		return this.client;
 	}
 

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -103,6 +103,15 @@ class ClickhouseService {
 	}
 
 	/**
+	 * Gets the ClickHouse client.
+	 *
+	 * @returns The ClickHouse client
+	 */
+	public getClient(): ClickHouseClient {
+		return this.client;
+	}
+
+	/**
 	 * Gets a table in ClickHouse if it exists.
 	 *
 	 * @param table The name of the table to get

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -160,3 +160,4 @@ class ClickhouseService {
 }
 
 export const clickhouseService = AsyncSingletonProxy(ClickhouseService);
+export type { ClickHouseColumn };

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -108,7 +108,7 @@ class ClickhouseService {
 	 * @returns The ClickHouse client
 	 */
 	public async getClient(): Promise<ClickHouseClient> {
-		return this.client;
+		return Promise.resolve(this.client);
 	}
 
 	/**

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -1,0 +1,169 @@
+/* * */
+
+import { AsyncSingletonProxy } from '@tmlmobilidade/utils';
+import { ClickHouseClient, createClient } from '@clickhouse/client';
+import { Logger } from '@tmlmobilidade/logger';
+import { ClickHouseColumn } from './types.js';
+import { isSafeIdentifier } from './utils.js';
+import { readFile } from 'fs/promises';
+
+/* * */
+
+
+class ClickhouseService {
+
+	private client: ClickHouseClient;
+	private static _instance: ClickhouseService;
+
+	private constructor() {
+
+		// Check missing environment variables
+		const missingEnvVars = [ 'CLICKHOUSE_DATABASE', 'CLICKHOUSE_URI'].filter(envVar => !process.env[envVar]);
+		if (missingEnvVars.length > 0) {
+			throw new Error(`Missing ClickHouse environment variables: ${missingEnvVars.join(', ')}`);
+		}
+
+		this.client = createClient({
+			database: process.env.CLICKHOUSE_DATABASE,
+			url: process.env.CLICKHOUSE_URI,
+		});
+	}
+
+	public static async getInstance() {
+		if (!ClickhouseService._instance) {
+			const instance = new ClickhouseService();
+			ClickhouseService._instance = instance;
+		}
+
+		return ClickhouseService._instance;
+	}
+
+	/**
+	 * Creates a table in ClickHouse if it doesn't exist.
+	 *
+	 * @param table The name of the table to create
+	 * @param schema The schema of the table to create
+	 * @param engine The ClickHouse table engine to use (default: MergeTree)
+	 * @param orderBy The ORDER BY clause for the table (default: tuple())
+	 */
+	public async createTable<T>(table: string, schema: ClickHouseColumn<T>[], engine = 'MergeTree', orderBy = 'tuple()') {
+
+		// Validate the table name
+		if (!isSafeIdentifier(table)) {
+			throw new Error(`CLICKHOUSE [${table}]: Unsafe table name provided.`);
+		}
+
+		// Validate the engine
+		if (!isSafeIdentifier(engine)) {
+			throw new Error(`CLICKHOUSE [${engine}]: Unsafe engine type provided.`);
+		}
+
+		// Validate the orderBy
+		if (!isSafeIdentifier(orderBy)) {
+			throw new Error(`CLICKHOUSE [${orderBy}]: Unsafe orderBy clause provided.`);
+		}
+
+		// Validate the schema
+		const unsafeColumns = schema.filter(column => !isSafeIdentifier(column.name)).map(column => column.name);
+		if (unsafeColumns.length > 0) {
+			throw new Error(`CLICKHOUSE [${table}]: Unsafe column names provided: ${unsafeColumns.join(', ')}.`);
+		}
+
+		try {
+			const createTableQuery = `
+				CREATE TABLE IF NOT EXISTS ${table} (
+					${schema.map(column => `${column.name} ${column.type}`).join(', ')}
+				) ENGINE = ${engine}
+				ORDER BY ${orderBy}
+			`;
+
+			await this.client.command({ query: createTableQuery });
+			Logger.info(`CLICKHOUSE [${table}]: Table created.`);
+		} catch (error) {
+			Logger.error(`CLICKHOUSE [${table}]: Error @ createTable(): ${(error as Error).message}`);
+			throw error;
+		}
+	}
+
+	/**
+	 * Deletes a table in ClickHouse if it exists.
+	 *
+	 * @param table The name of the table to delete
+	 */
+	public async deleteTable(table: string) {
+
+		// Validate the table name
+		if (!isSafeIdentifier(table)) {
+			throw new Error(`CLICKHOUSE [${table}]: Unsafe table name provided.`);
+		}
+
+		try {
+			await this.client.command({ query: `DROP TABLE IF EXISTS ${table}` });
+			Logger.info(`CLICKHOUSE [${table}]: Table deleted.`);
+		} catch (error) {
+			Logger.error(`CLICKHOUSE [${table}]: Error @ deleteTable(): ${(error as Error).message}`);
+			throw error;
+		}
+	}
+
+
+	/**
+	 * Gets a table in ClickHouse if it exists.
+	 *
+	 * @param table The name of the table to get
+	 * @returns The table schema
+	 */
+	public async getTable(table: string) {
+		try {
+			// Validate the table name
+			if (!isSafeIdentifier(table)) {
+				throw new Error(`CLICKHOUSE [${table}]: Unsafe table name provided.`);
+			}
+
+			const result = await this.client.command({ query: `SHOW CREATE TABLE ${table}` });
+			Logger.info(`CLICKHOUSE [${table}]: Table schema retrieved.`);
+			return result;
+		} catch (error) {
+			Logger.error(`CLICKHOUSE [${table}]: Error @ getTable(): ${(error as Error).message}`);
+			throw error;
+		}
+	}
+
+	/**
+	 * Executes a query from a SQL file.
+	 *
+	 * @param filePath Absolute or relative path to the .sql file
+	 * @param params Optional key-value substitutions applied to the query (replaces {key} placeholders)
+	 * @returns Query result rows typed as T
+	 */
+	public async queryFromFile<T>(filePath: string, params?: Record<string, string | number>): Promise<T[]> {
+		let sql: string;
+
+		try {
+			sql = await readFile(filePath, { encoding: 'utf-8' });
+		}
+		catch (error) {
+			Logger.error(`CLICKHOUSE: Error reading SQL file "${filePath}": ${(error as Error).message}`);
+			throw error;
+		}
+
+		// Simple named placeholder substitution
+		if (params) {
+			sql = sql.replace(/\{(\w+)\}/g, (_, key) => {
+				if (!(key in params)) throw new Error(`CLICKHOUSE "${filePath}": Missing query param: ${key}`);
+				return String(params[key]);
+			});
+		}
+
+		try {
+			const result = await this.client.query({ query: sql, format: 'JSONEachRow' });
+			return result.json<T>();
+		}
+		catch (error) {
+			Logger.error(`CLICKHOUSE: Error @ queryFromFile() "${filePath}": ${(error as Error).message}`);
+			throw error;
+		}
+	}
+}
+
+export const clickhouseService = AsyncSingletonProxy(ClickhouseService);

--- a/packages/clickhouse/src/types.ts
+++ b/packages/clickhouse/src/types.ts
@@ -1,21 +1,21 @@
 /**
  * Supported ClickHouse data types
  */
-export type ClickHouseType = 
- | 'Bool'
-	| 'Boolean' | 'Date32' | 'Date' | 'DateTime' | 'Decimal' | 'Float32'
-	| 'Float64' | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128'
-	| 'Int256' | 'String'
-	| 'UInt8' | 'UInt16'
-	| 'UInt32' | 'UInt64'
-	| 'UInt128' | 'UInt256' | 'UUID' | `Array(${string})`
-	| `DateTime64(${number})`
-	| `Decimal(${number}, ${number})`
-	| `Enum8(${string})`
-	| `Enum16(${string})`
-	| `FixedString(${number})`
-	| `LowCardinality(${string})` | `Map(${string}, ${string})`
-	| `Nullable(${string})`;
+export type ClickHouseType =
+  | 'Bool'
+  | 'Boolean' | 'Date32' | 'Date' | 'DateTime' | 'Decimal' | 'Float32'
+  | 'Float64' | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128'
+  | 'Int256' | 'String'
+  | 'UInt8' | 'UInt16'
+  | 'UInt32' | 'UInt64'
+  | 'UInt128' | 'UInt256' | 'UUID' | `Array(${string})`
+  | `DateTime64(${number})`
+  | `Decimal(${number}, ${number})`
+  | `Enum8(${string})`
+  | `Enum16(${string})`
+  | `FixedString(${number})`
+  | `LowCardinality(${string})` | `Map(${string}, ${string})`
+  | `Nullable(${string})`;
 
 export interface ClickHouseColumn<T> {
 	/** Alias expression (computed on read) */

--- a/packages/clickhouse/src/types.ts
+++ b/packages/clickhouse/src/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Supported ClickHouse data types
+ */
+export type ClickHouseType = 
+ | 'Bool'
+	| 'Boolean' | 'Date32' | 'Date' | 'DateTime' | 'Decimal' | 'Float32'
+	| 'Float64' | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128'
+	| 'Int256' | 'String'
+	| 'UInt8' | 'UInt16'
+	| 'UInt32' | 'UInt64'
+	| 'UInt128' | 'UInt256' | 'UUID' | `Array(${string})`
+	| `DateTime64(${number})`
+	| `Decimal(${number}, ${number})`
+	| `Enum8(${string})`
+	| `Enum16(${string})`
+	| `FixedString(${number})`
+	| `LowCardinality(${string})` | `Map(${string}, ${string})`
+	| `Nullable(${string})`;
+
+export interface ClickHouseColumn<T> {
+	/** Alias expression (computed on read) */
+	alias?: string
+
+	/** Column codec for compression */
+	codec?: string
+
+	/** Comment for the column */
+	comment?: string
+
+	/** Default value expression */
+	default?: string
+
+	/** Create a secondary index (skipping index) on this column */
+	indexed?: boolean
+
+	/** Granularity for the index. Default: 4 */
+	indexGranularity?: number
+
+	/** Type of skipping index. Default: 'minmax' */
+	indexType?: 'bloom_filter' | 'minmax' | 'ngrambf_v1' | 'set' | 'tokenbf_v1'
+
+	/** Use LowCardinality wrapper for low-cardinality strings */
+	lowCardinality?: boolean
+
+	/** Materialized value expression (computed on insert) */
+	materialized?: string
+
+	name: Extract<keyof T, string>
+
+	/** Whether the column can be null (wraps type in Nullable) */
+	nullable?: boolean
+
+	/** Include this column in the ORDER BY clause (ClickHouse's primary index) */
+	primaryKey?: boolean
+
+	/** Order of this column in the primary key (lower = first). Default: 0 */
+	primaryKeyOrder?: number
+
+	/** TTL expression for this column */
+	ttl?: string
+
+	/** The ClickHouse data type */
+	type: ClickHouseType
+}

--- a/packages/clickhouse/src/utils.ts
+++ b/packages/clickhouse/src/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Checks if a string is a safe identifier.
+ * This function is used to prevent SQL injection attacks.
+ * 
+ * @param str The string to check if it is a safe identifier.
+ * @returns True if the string is a safe identifier, false otherwise.
+ */
+export function isSafeIdentifier(str: string) {
+	return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(str);
+}

--- a/packages/clickhouse/tsconfig.json
+++ b/packages/clickhouse/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "@tmlmobilidade/tsconfig/nodejs.json",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"outDir": "dist",
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/eslint/src/rules/indent.ts
+++ b/packages/eslint/src/rules/indent.ts
@@ -13,6 +13,7 @@ export const indentConfig: Config[] = [
 			'@stylistic/indent': ['error', 'tab'],
 			'@stylistic/no-mixed-spaces-and-tabs': 'error',
 			'@stylistic/no-tabs': 'off',
+			'@stylistic/operator-linebreak': 'off',
 			'indent': 'off',
 		},
 	},

--- a/packages/writers/package.json
+++ b/packages/writers/package.json
@@ -34,7 +34,7 @@
 		"watch": "tsc-watch --onSuccess 'resolve-tspaths'"
 	},
 	"dependencies": {
-		"@clickhouse/client": "1.17.0",
+		"@tmlmobilidade/clickhouse": "*",
 		"@tmlmobilidade/logger": "*",
 		"@tmlmobilidade/timer": "*",
 		"papaparse": "5.5.3"

--- a/packages/writers/src/clickhouse.ts
+++ b/packages/writers/src/clickhouse.ts
@@ -11,21 +11,21 @@ import { Timer } from '@tmlmobilidade/timer';
 /**
  * Supported ClickHouse data types
  */
-export type ClickHouseType
-	= | 'Bool'
-	  | 'Boolean' | 'Date32' | 'Date' | 'DateTime' | 'Decimal' | 'Float32'
-	  | 'Float64' | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128'
-	  | 'Int256' | 'String'
-	  | 'UInt8' | 'UInt16'
-	  | 'UInt32' | 'UInt64'
-	  | 'UInt128' | 'UInt256' | 'UUID' | `Array(${string})`
-	  | `DateTime64(${number})`
-	  | `Decimal(${number}, ${number})`
-	  | `Enum8(${string})`
-	  | `Enum16(${string})`
-	  | `FixedString(${number})`
-	  | `LowCardinality(${string})` | `Map(${string}, ${string})`
-	  | `Nullable(${string})`;
+export type ClickHouseType =
+  | 'Bool'
+  | 'Boolean' | 'Date32' | 'Date' | 'DateTime' | 'Decimal' | 'Float32'
+  | 'Float64' | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128'
+  | 'Int256' | 'String'
+  | 'UInt8' | 'UInt16'
+  | 'UInt32' | 'UInt64'
+  | 'UInt128' | 'UInt256' | 'UUID' | `Array(${string})`
+  | `DateTime64(${number})`
+  | `Decimal(${number}, ${number})`
+  | `Enum8(${string})`
+  | `Enum16(${string})`
+  | `FixedString(${number})`
+  | `LowCardinality(${string})` | `Map(${string}, ${string})`
+  | `Nullable(${string})`;
 
 export interface ClickHouseColumn<T> {
 	/** Alias expression (computed on read) */

--- a/packages/writers/src/clickhouse.ts
+++ b/packages/writers/src/clickhouse.ts
@@ -11,21 +11,21 @@ import { Timer } from '@tmlmobilidade/timer';
 /**
  * Supported ClickHouse data types
  */
-export type ClickHouseType =
-  | 'Bool'
-  | 'Boolean' | 'Date32' | 'Date' | 'DateTime' | 'Decimal' | 'Float32'
-  | 'Float64' | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128'
-  | 'Int256' | 'String'
-  | 'UInt8' | 'UInt16'
-  | 'UInt32' | 'UInt64'
-  | 'UInt128' | 'UInt256' | 'UUID' | `Array(${string})`
-  | `DateTime64(${number})`
-  | `Decimal(${number}, ${number})`
-  | `Enum8(${string})`
-  | `Enum16(${string})`
-  | `FixedString(${number})`
-  | `LowCardinality(${string})` | `Map(${string}, ${string})`
-  | `Nullable(${string})`;
+export type ClickHouseType
+	= | 'Bool'
+	  | 'Boolean' | 'Date32' | 'Date' | 'DateTime' | 'Decimal' | 'Float32'
+	  | 'Float64' | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128'
+	  | 'Int256' | 'String'
+	  | 'UInt8' | 'UInt16'
+	  | 'UInt32' | 'UInt64'
+	  | 'UInt128' | 'UInt256' | 'UUID' | `Array(${string})`
+	  | `DateTime64(${number})`
+	  | `Decimal(${number}, ${number})`
+	  | `Enum8(${string})`
+	  | `Enum16(${string})`
+	  | `FixedString(${number})`
+	  | `LowCardinality(${string})` | `Map(${string}, ${string})`
+	  | `Nullable(${string})`;
 
 export interface ClickHouseColumn<T> {
 	/** Alias expression (computed on read) */
@@ -144,16 +144,14 @@ export class ClickHouseWriter<T> {
 		if (params.client) {
 			this.params = params;
 			this.client = params.client as ClickHouseClient;
-		}
-		else if (params.clientConfig) {
+		} else if (params.clientConfig) {
 			const { database, password, url, username } = params.clientConfig;
 			if (!database || !password || !url || !username) {
 				throw new Error('CLICKHOUSEWRITER: Client configuration is invalid. Ensure database, password, url and username are provided.');
 			}
 			this.params = params;
 			this.client = createClient(params.clientConfig);
-		}
-		else {
+		} else {
 			throw new Error('CLICKHOUSEWRITER: Either client or clientConfig is required.');
 		}
 	}
@@ -193,8 +191,7 @@ export class ClickHouseWriter<T> {
 
 			await this.client.command({ query: createTableQuery });
 			Logger.info(`CLICKHOUSEWRITER [${this.params.table}]: Table ensured.`);
-		}
-		catch (error) {
+		} catch (error) {
 			Logger.error(`CLICKHOUSEWRITER [${this.params.table}]: Error @ ensureTable(): ${(error as Error).message}`);
 			throw error;
 		}
@@ -246,8 +243,7 @@ export class ClickHouseWriter<T> {
 							break;
 					}
 				}
-			}
-			else {
+			} else {
 				// Simple equality
 				conditions.push(`${key} = ${this.formatValue(value)}`);
 			}
@@ -291,8 +287,7 @@ export class ClickHouseWriter<T> {
 
 			const data = await result.json() as { count: string }[];
 			return parseInt(data[0]?.count ?? '0', 10);
-		}
-		catch (error) {
+		} catch (error) {
 			Logger.error(`CLICKHOUSEWRITER [${this.params.table}]: Error @ countDocuments(): ${(error as Error).message}`);
 			throw error;
 		}
@@ -324,8 +319,7 @@ export class ClickHouseWriter<T> {
 
 			const data = await result.json() as Record<string, K>[];
 			return data.map(row => row[column]);
-		}
-		catch (error) {
+		} catch (error) {
 			Logger.error(`CLICKHOUSEWRITER [${this.params.table}]: Error @ distinct(): ${(error as Error).message}`);
 			throw error;
 		}
@@ -401,15 +395,13 @@ export class ClickHouseWriter<T> {
 				this.dataBucketFlushOps = [];
 
 				//
-			}
-			catch (error) {
+			} catch (error) {
 				Logger.error(`CLICKHOUSEWRITER [${this.params.table}]: Error @ flush().insert(): ${(error as Error).message}`);
 				throw error; // Re-throw to allow retry logic at higher level
 			}
 
 			//
-		}
-		catch (error) {
+		} catch (error) {
 			Logger.error(`CLICKHOUSEWRITER [${this.params.table}]: Error @ flush(): ${(error as Error).message}`);
 			throw error; // Re-throw to allow retry logic at higher level
 		}
@@ -460,8 +452,7 @@ export class ClickHouseWriter<T> {
 		if (Array.isArray(data)) {
 			const combinedDataWithOptions = data.map(item => item);
 			this.dataBucketAlwaysAvailable = [...this.dataBucketAlwaysAvailable, ...combinedDataWithOptions];
-		}
-		else {
+		} else {
 			this.dataBucketAlwaysAvailable.push(data);
 		}
 

--- a/packages/writers/src/clickhouse.ts
+++ b/packages/writers/src/clickhouse.ts
@@ -3,75 +3,11 @@
 
 import { type ClickHouseClient, type ClickHouseClientConfigOptions, createClient } from '@clickhouse/client';
 import { NodeClickHouseClient } from '@clickhouse/client/dist/client.js';
+import { ClickHouseColumn } from '@tmlmobilidade/clickhouse';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';
 
 /* * */
-
-/**
- * Supported ClickHouse data types
- */
-export type ClickHouseType =
-  | 'Bool'
-  | 'Boolean' | 'Date32' | 'Date' | 'DateTime' | 'Decimal' | 'Float32'
-  | 'Float64' | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128'
-  | 'Int256' | 'String'
-  | 'UInt8' | 'UInt16'
-  | 'UInt32' | 'UInt64'
-  | 'UInt128' | 'UInt256' | 'UUID' | `Array(${string})`
-  | `DateTime64(${number})`
-  | `Decimal(${number}, ${number})`
-  | `Enum8(${string})`
-  | `Enum16(${string})`
-  | `FixedString(${number})`
-  | `LowCardinality(${string})` | `Map(${string}, ${string})`
-  | `Nullable(${string})`;
-
-export interface ClickHouseColumn<T> {
-	/** Alias expression (computed on read) */
-	alias?: string
-
-	/** Column codec for compression */
-	codec?: string
-
-	/** Comment for the column */
-	comment?: string
-
-	/** Default value expression */
-	default?: string
-
-	/** Create a secondary index (skipping index) on this column */
-	indexed?: boolean
-
-	/** Granularity for the index. Default: 4 */
-	indexGranularity?: number
-
-	/** Type of skipping index. Default: 'minmax' */
-	indexType?: 'bloom_filter' | 'minmax' | 'ngrambf_v1' | 'set' | 'tokenbf_v1'
-
-	/** Use LowCardinality wrapper for low-cardinality strings */
-	lowCardinality?: boolean
-
-	/** Materialized value expression (computed on insert) */
-	materialized?: string
-
-	name: Extract<keyof T, string>
-
-	/** Whether the column can be null (wraps type in Nullable) */
-	nullable?: boolean
-
-	/** Include this column in the ORDER BY clause (ClickHouse's primary index) */
-	primaryKey?: boolean
-
-	/** Order of this column in the primary key (lower = first). Default: 0 */
-	primaryKeyOrder?: number
-
-	/** TTL expression for this column */
-	ttl?: string
-
-	/** The ClickHouse data type */
-	type: ClickHouseType
-}
 
 type ClickHouseWriterParams<T> = {
 	/**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new shared ClickHouse client/service abstraction and updates writers to depend on it; changes touch DB query/table creation paths, so misconfiguration or unsafe SQL composition could impact runtime behavior.
> 
> **Overview**
> Introduces a new `@tmlmobilidade/clickhouse` package that centralizes ClickHouse client creation and provides helpers for `createTable`, `deleteTable`, `getTable`, and running SQL from files with basic placeholder substitution, plus shared `ClickHouseColumn` typing and identifier validation.
> 
> Updates `@tmlmobilidade/writers` to depend on the new package and removes its local ClickHouse schema/type definitions in favor of importing `ClickHouseColumn`, with only minor formatting/lint-related adjustments elsewhere (ESLint indent rule disables `operator-linebreak`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09c7dd612da831ce6dbc11eb700b3c3f7c02e1e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->