### PR TITLE
feat: update EmailProvider to use OAuth2 for SMTP authentication and …

### DIFF
--- a/packages/emails/AUTHENTICATE.md
+++ b/packages/emails/AUTHENTICATE.md
@@ -1,0 +1,30 @@
+
+# Authenticate using OAuth2 with Microsoft 365
+
+At the end of this guide you will have generated the necessary refresh token to be used in the nodemailer package.
+To do this you need to have a Client ID, a Client Secret and an Access URL to authorize against.
+
+
+### 1. Authorization Request
+
+In a broswer, go to the following URL, replacing the necessary variables:
+
+`https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/authorize?client_id={CLIENT_ID}&response_type=code&response_mode=query&scope=openid%20profile%20offline_access%20https://outlook.office365.com/.default&redirect_uri=http://localhost`
+
+The app needs to be configured to accept the `redirect_uri="http://localhost"`. This means the authorize endpoint will redirect the page to `http://localhost/?code=your_new_code`. You then need to grab this code and use it in the next step.
+
+
+### 2. Authorization Request
+
+Using Postman, make a `POST` request to this URL: `https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token`
+
+Using the `x-www-form-urlencoded` body type to include the necessary parameters:
+
+- `client_id`: Your application ID
+- `client_secret`: Your application secret
+- `code`: The code from the previous step
+- `grant_type`: `authorization_code`
+- `redirect_uri`: `http://localhost`
+- `scope`: `openid profile offline_access https://outlook.office365.com/.default`
+
+If the request is successful, the response will be a JSON with a `refresh_token` value.

--- a/packages/emails/src/email.provider.ts
+++ b/packages/emails/src/email.provider.ts
@@ -12,8 +12,8 @@ export class EmailProvider {
 	private _smtp_transporter: nodemailer.Transporter;
 
 	/**
-     * Return the instance of the EmailProvider.
-     */
+	 * Return the instance of the EmailProvider.
+	 */
 	public static async getInstance() {
 		if (!EmailProvider._instance) {
 			const instance = new EmailProvider();
@@ -24,72 +24,58 @@ export class EmailProvider {
 	}
 
 	/**
-     * Connect to MongoDB and return the database instance.
-     */
+	 * Connect to the SMTP server and return the transporter instance.
+	 */
 	async connect(): Promise<nodemailer.Transporter> {
 		try {
 			// Check for required environment variables
-			const requiredEnvVars = [
-				'TML_PROVIDER_EMAIL_SERVER_PASSWORD',
-				'TML_PROVIDER_EMAIL_SERVER_USER',
-				'TML_PROVIDER_EMAIL_FROM',
-				'TML_PROVIDER_EMAIL_SERVER_HOST',
-				'TML_PROVIDER_EMAIL_SERVER_PORT',
-			];
-
-			const missingVars = requiredEnvVars.filter(key => !process.env[key]);
-			if (missingVars.length > 0) {
-				throw new Error(
-					`Missing required environment variable(s): ${missingVars.join(', ')}`,
-				);
-			}
-
-			// Create the SMTP transporter
-			const smtpTransportOptions = {
+			if (!process.env.TML_PROVIDER_EMAIL_SERVER_HOST) throw new Error('Missing required environment variable: TML_PROVIDER_EMAIL_SERVER_HOST');
+			if (!process.env.TML_PROVIDER_EMAIL_SERVER_PORT) throw new Error('Missing required environment variable: TML_PROVIDER_EMAIL_SERVER_PORT');
+			if (!process.env.TML_PROVIDER_EMAIL_AUTH_CLIENT_ID) throw new Error('Missing required environment variable: TML_PROVIDER_EMAIL_AUTH_CLIENT_ID');
+			if (!process.env.TML_PROVIDER_EMAIL_AUTH_CLIENT_SECRET) throw new Error('Missing required environment variable: TML_PROVIDER_EMAIL_AUTH_CLIENT_SECRET');
+			if (!process.env.TML_PROVIDER_EMAIL_AUTH_ACCESS_URL) throw new Error('Missing required environment variable: TML_PROVIDER_EMAIL_AUTH_ACCESS_URL');
+			if (!process.env.TML_PROVIDER_EMAIL_AUTH_REFRESH_TOKEN) throw new Error('Missing required environment variable: TML_PROVIDER_EMAIL_AUTH_REFRESH_TOKEN');
+			if (!process.env.TML_PROVIDER_EMAIL_AUTH_USER) throw new Error('Missing required environment variable: TML_PROVIDER_EMAIL_AUTH_USER');
+			if (!process.env.TML_PROVIDER_EMAIL_FROM) throw new Error('Missing required environment variable: TML_PROVIDER_EMAIL_FROM');
+			// Connect to the SMTP server
+			this._smtp_transporter = nodemailer.createTransport({
 				auth: {
-					pass: process.env.TML_PROVIDER_EMAIL_SERVER_PASSWORD,
-					user: process.env.TML_PROVIDER_EMAIL_SERVER_USER,
+					accessUrl: process.env.TML_PROVIDER_EMAIL_AUTH_ACCESS_URL,
+					clientId: process.env.TML_PROVIDER_EMAIL_AUTH_CLIENT_ID,
+					clientSecret: process.env.TML_PROVIDER_EMAIL_AUTH_CLIENT_SECRET,
+					refreshToken: process.env.TML_PROVIDER_EMAIL_AUTH_REFRESH_TOKEN,
+					type: 'OAuth2',
+					user: process.env.TML_PROVIDER_EMAIL_AUTH_USER,
 				},
 				from: process.env.TML_PROVIDER_EMAIL_FROM,
 				host: process.env.TML_PROVIDER_EMAIL_SERVER_HOST,
 				port: Number(process.env.TML_PROVIDER_EMAIL_SERVER_PORT),
-			};
-			// Connect to the SMTP server
-			this._smtp_transporter = nodemailer.createTransport(smtpTransportOptions);
+			});
 			return this._smtp_transporter;
-		}
-		catch (error) {
+		} catch (error) {
 			throw new Error('Error connecting to SMTP server', { cause: error });
 		}
 	}
 
 	/**
-     * Send an email.
-	 *
+	 * Send an email.
 	 * @param emailOptions - The email options.
 	 * @returns A promise that resolves when the email is sent.
-     */
-	async send({
-		html,
-		subject,
-		to,
-		...options
-	}: nodemailer.SendMailOptions) {
+	 */
+	async send(sendMailOptions: nodemailer.SendMailOptions) {
 		try {
 			await this._smtp_transporter.sendMail({
 				...this._smtp_transporter.options,
-				html,
-				subject,
-				to,
-				...options,
+				...sendMailOptions,
 			});
-		}
-		catch (error) {
+		} catch (error) {
 			throw new Error('Error sending email', { cause: error });
 		}
 	}
 
 	//
 }
+
+/* * */
 
 export const emailProvider = AsyncSingletonProxy(EmailProvider);


### PR DESCRIPTION
This pull request updates the email authentication workflow to support OAuth2 with Microsoft 365, replacing the previous username/password approach. The main changes include new documentation for OAuth2 authentication and an updated `EmailProvider` class to use OAuth2 credentials and environment variables.