### PR TITLE
Refactor env-sync workflow to prune and build CLI, update working dir…

### DIFF
--- a/.github/workflows/env-sync.yml
+++ b/.github/workflows/env-sync.yml
@@ -47,15 +47,16 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Build env-sync CLI
-        working-directory: ./cli/env-sync
-        run: npm run build
+      - name: Prune and build env-sync only
+        run: |
+          npx turbo prune @tmlmobilidade/env-sync --out-dir=out
+          cd out && npm install && npx turbo run build --filter=@tmlmobilidade/env-sync
 
       # # # # # # # # # # # # # # # # # # # # #
       # Secrets / Environment Setup
       # # # # # # # # # # # # # # # # # # # # #
       - name: Configure Secrets (.env + key file)
-        working-directory: ./cli/env-sync
+        working-directory: ./out/cli/env-sync
         run: |
           mkdir -p secrets
 
@@ -78,7 +79,7 @@ jobs:
       - name: Verify .env configuration
         uses: ./.github/actions/verify-env
         with:
-          env-path: ./cli/env-sync/.env
+          env-path: ./out/cli/env-sync/.env
           required-vars: |
             OCI_KEY_FILE
             OCI_COMPARTMENT
@@ -109,7 +110,7 @@ jobs:
       # Run Sync
       # # # # # # # # # # # # # # # # # # # # #
       - name: Run Environment Sync
-        working-directory: ./cli/env-sync
+        working-directory: ./out/cli/env-sync
         run: |
           set -e
           echo "Running DB sync..."
@@ -123,7 +124,7 @@ jobs:
       # # # # # # # # # # # # # # # # # # # # #
       - name: Upload backup artifacts to OCI
         if: always()
-        working-directory: ./cli/env-sync
+        working-directory: ./out/cli/env-sync
         run: |
           echo "Uploading artifacts to OCI bucket..."
           node dist/index.js --upload-artifacts || echo "Artifact upload failed or no artifacts to upload"


### PR DESCRIPTION
…ectories for environment configuration and artifact upload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI execution/build strategy and working directories for a production→staging sync job; if pruning misses dependencies or paths are wrong, the scheduled sync could fail.
> 
> **Overview**
> Updates the `env-sync` GitHub Actions workflow to **build only the `@tmlmobilidade/env-sync` CLI** via `npx turbo prune` and a filtered Turbo build, instead of building from the full repo.
> 
> Adjusts subsequent steps to run from the pruned output (`./out/cli/env-sync`), including secret/.env creation, `.env` verification path, the sync execution commands, and OCI artifact upload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7931722a2022cb8ab1ddf846f3f99d00ce1ea4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->