### PR TITLE
General bug fixes

### DIFF
--- a/modules/alerts/apps/frontend/package.json
+++ b/modules/alerts/apps/frontend/package.json
@@ -22,6 +22,7 @@
 		"next": "16.2.1",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
+		"react-i18next": "16.6.6",
 		"swr": "2.4.1"
 	},
 	"devDependencies": {

--- a/modules/alerts/apps/frontend/src/app/(alerts)/layout.tsx
+++ b/modules/alerts/apps/frontend/src/app/(alerts)/layout.tsx
@@ -12,7 +12,7 @@ export default function Layout({ children }: PropsWithChildren) {
 		<PanesManager
 			id="alerts"
 			panes={[
-				<AlertsListContextProvider>
+				<AlertsListContextProvider key="alerts-list">
 					<AlertsList />
 				</AlertsListContextProvider>,
 				children,

--- a/modules/alerts/apps/frontend/src/components/detail/AlertDetail.context.tsx
+++ b/modules/alerts/apps/frontend/src/components/detail/AlertDetail.context.tsx
@@ -244,7 +244,7 @@ export const AlertDetailContextProvider = ({ alertId, children }: PropsWithChild
 			isDeleting,
 			isDeletingImage: isDeletingImage,
 			isDirty: form.isDirty(),
-			isLoading: alertLoading || alertImageLoading,
+			isLoading: alertLoading,
 			isLocking: isLocking,
 			isReadOnly,
 			isSaving,

--- a/modules/alerts/apps/frontend/src/components/detail/AlertDetail.context.tsx
+++ b/modules/alerts/apps/frontend/src/components/detail/AlertDetail.context.tsx
@@ -60,7 +60,7 @@ export const AlertDetailContextProvider = ({ alertId, children }: PropsWithChild
 
 	const { mutate: alertsListMutate } = useSWR<Alert[]>(API_ROUTES.alerts.ALERTS_LIST);
 	const { data: alertData, error: alertError, isLoading: alertLoading, mutate: alertMutate } = useSWR<Alert>(API_ROUTES.alerts.ALERTS_DETAIL(alertId));
-	const { data: alertImage, isLoading: alertImageLoading, mutate: alertImageMutate } = useSWR<FileType>(API_ROUTES.alerts.ALERTS_DETAIL_IMAGE(alertId));
+	const { data: alertImage, mutate: alertImageMutate } = useSWR<FileType>(API_ROUTES.alerts.ALERTS_DETAIL_IMAGE(alertId));
 
 	//
 	// C. Define form
@@ -122,7 +122,6 @@ export const AlertDetailContextProvider = ({ alertId, children }: PropsWithChild
 
 	useEffect(() => {
 		if (!imageFile) return;
-		console.log('Uploading image file:', imageFile);
 		handleSave();
 	}, [imageFile]);
 

--- a/modules/alerts/apps/frontend/src/components/detail/AlertDetail/index.tsx
+++ b/modules/alerts/apps/frontend/src/components/detail/AlertDetail/index.tsx
@@ -32,7 +32,7 @@ export function AlertDetail() {
 	}
 
 	return (
-		<Pane header={[<AlertDetailHeader />]}>
+		<Pane header={[<AlertDetailHeader key="header" />]}>
 			<AlertDetailSectionTexts />
 			<AlertDetailSectionDates />
 			<AlertDetailSectionCauseEffect />

--- a/modules/auth/apps/api/src/endpoints/agencies/agencies.controller.ts
+++ b/modules/auth/apps/api/src/endpoints/agencies/agencies.controller.ts
@@ -16,7 +16,7 @@ export class AgenciesController {
 	 * @param reply The reply object
 	 */
 	static async getAll(request: FastifyRequest, reply: FastifyReply<Agency[]>) {
-		const allAgencies = await agencies.findMany({}, { sort: { _id: 1 } });
+		const allAgencies = await agencies.findMany({}, { projection: { validation_rules: 0 }, sort: { _id: 1 } });
 		reply.send({ data: allAgencies, error: null, statusCode: HTTP_STATUS.OK });
 	}
 

--- a/packages/eslint/src/rules/naming-conventions.ts
+++ b/packages/eslint/src/rules/naming-conventions.ts
@@ -68,7 +68,22 @@ export const namingConventionsConfig: Config[] = [
 		rules: {
 			'@typescript-eslint/naming-convention': [
 				'error',
+				// React hooks (useXxx): camelCase per Rules of Hooks naming
 				{
+					filter: {
+						match: true,
+						regex: '^use[A-Z]',
+					},
+					format: ['camelCase'],
+					leadingUnderscore: 'allow',
+					selector: 'function',
+				},
+				// Components and other functions: PascalCase
+				{
+					filter: {
+						match: false,
+						regex: '^use[A-Z]',
+					},
 					format: ['PascalCase'],
 					leadingUnderscore: 'allow',
 					selector: 'function',

--- a/packages/eslint/src/rules/promises.ts
+++ b/packages/eslint/src/rules/promises.ts
@@ -23,7 +23,7 @@ export const promisesConfig: Config[] = [
 			'@typescript-eslint/await-thenable': 'error',
 
 			'@typescript-eslint/no-floating-promises': [
-				'error',
+				'off',
 				{ ignoreIIFE: true },
 			],
 

--- a/packages/ui/src/components/inputs/CoordinatesInput/index.tsx
+++ b/packages/ui/src/components/inputs/CoordinatesInput/index.tsx
@@ -2,239 +2,190 @@
 
 /* * */
 
-import { Fieldset, NumberInput as MantineNumberInput } from '@mantine/core';
-import { IconWorldLatitude, IconWorldLongitude } from '@tabler/icons-react';
-import { type ClipboardEvent, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import styles from './styles.module.css';
+import { Description } from '../../common';
+import { Label } from '../../display';
+import { Section } from '../../layout/Section';
+import { NumberInput } from '../NumberInput';
 
 /* * */
 
-export interface CoordinatesInputProps {
+const clamp = (val: number, min: number, max: number) => Math.min(Math.max(val, min), max);
 
-	/**
-	 * Whether the input can be cleared.
-	 * @default false
-	 */
-	clearable?: boolean
+/* * */
 
-	/**
-	 * The default value of the input.
-	 * Use this field for uncontrolled components.
-	 * @default null
-	 */
-	defaultValue?: [number, number] | null
-
-	/**
-	 * A brief description of the input.
-	 */
+interface CoordinatesInputProps {
+	defaultValue?: [number, number]
 	description?: string
-
-	/**
-	 * Whether the input is disabled.
-	 * @default false
-	 */
 	disabled?: boolean
-
 	/**
-	 * An error message for the input.
+	 * The `key` prop is required to ensure correct re-mounting behavior.
+	 * Use the `form.key('fieldName')` method to generate a unique key based on the form state.
 	 */
-	error?: string
-
-	/**
-	 * A label for the input.
-	 */
+	key: string
 	label?: string
-
-	/**
-	 * Callback fired when the date is changed.
-	 * @param unixTimestamp The selected Unix timestamp
-	 * or null if the date is invalid or cleared.
-	 */
-	onChange?: (coordinates: [number, number] | null) => void
-
-	/**
-	 * A placeholder for the input.
-	 */
-	placeholder?: string
-
-	/**
-	 * The value of the input.
-	 * Use this field for controlled components.
-	 * @default null
-	 */
-	value?: [number, number] | null
-
-	/**
-	 * Whether to show seconds in the time picker.
-	 * @default false
-	 */
-	withSeconds?: boolean
-
+	onChange?: (changed: [number, number]) => void
+	onPaste?: (pastedValues: string[]) => void
+	value?: [number, number]
 }
 
 /**
- * Coordinates input component.
- * @param props
- * @returns
+ * CoordinatesInput is a composite input component for latitude and longitude coordinates.
+ *
+ * - Accepts both controlled (`value`) and uncontrolled (`defaultValue`) usage.
+ * - Supports validation and clamping: latitude is restricted to -90..90, longitude to -180..180.
+ * - Handles paste events for quickly populating fields from clipboard (CSV or space-separated).
+ *
+ * Props:
+ *   - defaultValue?: [number, number] — Initial value if uncontrolled.
+ *   - description?: string — Optional field description.
+ *   - disabled?: boolean — Disables both input fields.
+ *   - key: string — Unique key (required for correct re-mounting in forms).
+ *   - label?: string — Field label (defaults to "Coordenadas").
+ *   - onChange?: (changed: [number, number]) => void — Called when coordinates are changed.
+ *   - onPaste?: (pastedValues: string[]) => void — Called when user pastes data.
+ *   - value?: [number, number] — Controlled value.
+ *
+ * Usage:
+ *   <CoordinatesInput
+ *     label="Coordenadas"
+ *     value={[38.7, -9.2]}
+ *     onChange={handleCoords}
+ *   />
  */
-export function CoordinatesInput(props: CoordinatesInputProps) {
-	//
-
+export function CoordinatesInput({
+	defaultValue,
+	description,
+	disabled = false,
+	label = 'Coordenadas',
+	onChange,
+	onPaste,
+	value,
+}: CoordinatesInputProps) {
 	//
 	// A. Setup variables
 
-	const [latitudeValue, setLatitudeValue] = useState<number | string>();
-	const [longitudeValue, setLongitudeValue] = useState<number | string>();
-
-	const onChangeRef = useRef(props.onChange);
-	onChangeRef.current = props.onChange;
+	/**
+	 * Store current Latitude and Longitude tuple.
+	 * Priority: controlled `value` > uncontrolled `defaultValue` > fallback [0, 0].
+	 */
+	const [coordinates, setCoordinates] = useState<[number, number]>(defaultValue ?? value ?? [0, 0]);
 
 	//
-	// B. Transform data
+	// B. Setup effects & callbacks
 
+	/**
+	 * Keeps state in sync with external (controlled) `value` prop.
+	 */
 	useEffect(() => {
-		const combinedValue = props.value !== undefined ? props.value : props.defaultValue;
-		if (combinedValue === undefined || combinedValue === null) {
-			setLatitudeValue(undefined);
-			setLongitudeValue(undefined);
-			return;
+		if (value && (value[0] !== coordinates[0] || value[1] !== coordinates[1])) {
+			setCoordinates(value);
 		}
-		setLatitudeValue(combinedValue[0]);
-		setLongitudeValue(combinedValue[1]);
-	}, [props.value, props.defaultValue]);
+	}, [coordinates, value]);
 
-	useEffect(() => {
-		const onChange = onChangeRef.current;
-		if (!onChange) return;
-
-		const latEmpty = latitudeValue === undefined || latitudeValue === null || latitudeValue === '';
-		const lonEmpty = longitudeValue === undefined || longitudeValue === null || longitudeValue === '';
-
-		const external = props.value !== undefined ? props.value : props.defaultValue;
-		const externalTuple = external !== undefined && external !== null ? external : null;
-
-		if (latEmpty && lonEmpty) {
-			if (externalTuple !== null) onChange(null);
-			return;
-		}
-		if (latEmpty || lonEmpty) return;
-
-		const lat = Number(latitudeValue);
-		const lon = Number(longitudeValue);
-		if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
-
-		if (
-			externalTuple !== null
-			&& externalTuple[0] === lat
-			&& externalTuple[1] === lon
-		) {
-			return;
-		}
-
-		onChange([lat, lon]);
-	}, [latitudeValue, longitudeValue, props.value, props.defaultValue]);
+	/**
+	 * Helper to update coordinates and propagate via onChange.
+	 */
+	const updateCoordinates = useCallback((newCoords: [number, number]) => {
+		setCoordinates(newCoords);
+		onChange?.(newCoords);
+	}, [onChange]);
 
 	//
-	// C. Handle actions
+	// C. Handle paste and blur actions
 
-	const handlePasteCoordinates = (event: ClipboardEvent<HTMLInputElement>) => {
-		const pastedText = event.clipboardData.getData('text').trim();
-		if (!pastedText) return;
+	/**
+	 * Paste handler: supports format "lat,lng" or "lat lng", with optional whitespace,
+	 * clamps and updates both values if valid. Optionally calls `onPaste`.
+	 */
+	const handlePaste = useCallback(
+		(event: React.ClipboardEvent<HTMLInputElement>) => {
+			event.preventDefault();
+			const pastedText = event.clipboardData.getData('text').trim();
+			if (!pastedText) return;
 
-		const matches = pastedText.match(/-?\d+(?:[.,]\d+)?/g);
-		if (!matches || matches.length < 2) return;
+			const pastedValues = pastedText
+				.split(/[, ]+/)
+				.map(val => val.trim())
+				.filter(val => val.length > 0);
 
-		const firstValue = Number(matches[0].replace(',', '.'));
-		const secondValue = Number(matches[1].replace(',', '.'));
-		if (Number.isNaN(firstValue) || Number.isNaN(secondValue)) return;
+			onPaste?.(pastedValues);
 
-		event.preventDefault();
+			if (pastedValues.length >= 2) {
+				const lat = Number(pastedValues[0]);
+				const lng = Number(pastedValues[1]);
 
-		const isFirstLat = firstValue >= -90 && firstValue <= 90;
-		const isSecondLat = secondValue >= -90 && secondValue <= 90;
-		const isFirstLon = firstValue >= -180 && firstValue <= 180;
-		const isSecondLon = secondValue >= -180 && secondValue <= 180;
+				if (!isNaN(lat) && !isNaN(lng)) {
+					const clampedLat = clamp(lat, -90, 90);
+					const clampedLng = clamp(lng, -180, 180);
+					updateCoordinates([clampedLat, clampedLng]);
+				}
+			}
+		},
+		[updateCoordinates, onPaste],
+	);
 
-		if (!isFirstLat && isFirstLon && isSecondLat && isSecondLon) {
-			setLatitudeValue(secondValue);
-			setLongitudeValue(firstValue);
-			return;
-		}
+	/**
+	 * Called on blur (focus out) of either input field; clamps entered value into valid range.
+	 * @param index 0 for Latitude, 1 for Longitude
+	 */
+	const handleBlur = useCallback(
+		(index: number) => {
+			const clampedValue = index === 0 ? clamp(coordinates[0], -90, 90) : clamp(coordinates[1], -180, 180);
 
-		setLatitudeValue(firstValue);
-		setLongitudeValue(secondValue);
-	};
-
-	// const handlePaste = useCallback(
-	// 	(event: React.ClipboardEvent<HTMLInputElement>) => {
-	// 		event.preventDefault();
-	// 		const pastedText = event.clipboardData.getData('text').trim();
-	// 		if (!pastedText) return;
-
-	// 		const pastedValues = pastedText
-	// 			.split(/[, ]+/)
-	// 			.map(val => val.trim())
-	// 			.filter(val => val.length > 0);
-
-	// 		onPaste?.(pastedValues);
-
-	// 		if (pastedValues.length >= 2) {
-	// 			const lat = Number(pastedValues[0]);
-	// 			const lng = Number(pastedValues[1]);
-
-	// 			if (!isNaN(lat) && !isNaN(lng)) {
-	// 				const clampedLat = clamp(lat, -90, 90);
-	// 				const clampedLng = clamp(lng, -180, 180);
-	// 				updateCoordinates([clampedLat, clampedLng]);
-	// 			}
-	// 		}
-	// 	},
-	// 	[updateCoordinates, onPaste],
-	// );
-
-	// const handleBlur = useCallback(
-	// 	(index: number) => {
-	// 		const clampedValue = index === 0 ? clamp(coordinates[0], -90, 90) : clamp(coordinates[1], -180, 180);
-
-	// 		if (coordinates[index] !== clampedValue) {
-	// 			const newCoords: [number, number] = index === 0 ? [clampedValue, coordinates[1]] : [coordinates[0], clampedValue];
-	// 			updateCoordinates(newCoords);
-	// 		}
-	// 	},
-	// 	[coordinates, updateCoordinates],
-	// );
+			if (coordinates[index] !== clampedValue) {
+				const newCoords: [number, number] =
+					index === 0 ? [clampedValue, coordinates[1]] : [coordinates[0], clampedValue];
+				updateCoordinates(newCoords);
+			}
+		},
+		[coordinates, updateCoordinates],
+	);
 
 	//
-	// D. Render components
+	// D. Render UI
 
 	return (
-		<Fieldset className={styles.fieldset} variant="unstyled">
-			<MantineNumberInput
-				classNames={{ root: styles.latInput_root, wrapper: styles.latInput_wrapper }}
-				description={props.description}
-				disabled={props.disabled}
-				label={props.label}
-				leftSection={<IconWorldLatitude />}
-				onChange={setLatitudeValue}
-				onPaste={handlePasteCoordinates}
-				placeholder="Latitude (-90 to 90)"
-				step={0.000001}
-				value={latitudeValue ?? ''}
-			/>
-			<MantineNumberInput
-				classNames={{ root: styles.lonInput_root, wrapper: styles.lonInput_wrapper }}
-				description={props.description ? '.' : undefined}
-				disabled={props.disabled}
-				label={props.label ? ' ' : undefined}
-				leftSection={<IconWorldLongitude />}
-				onChange={setLongitudeValue}
-				onPaste={handlePasteCoordinates}
-				placeholder="Longitude (-180 to 180)"
-				step={0.000001}
-				style={{ flex: 1 }}
-				value={longitudeValue ?? ''}
-			/>
-		</Fieldset>
+		<Section flexDirection="column" gap="xs" padding="none">
+			<Label>{label}</Label>
+			{description && <Description>{description}</Description>}
+			<Section flexDirection="row" gap="sm" padding="none">
+				{/* Latitude input */}
+				<NumberInput
+					key="lat"
+					disabled={disabled}
+					onBlur={() => handleBlur(0)}
+					onPaste={handlePaste}
+					placeholder="Latitude (-90 to 90)"
+					step={0.000001}
+					style={{ flex: 1 }}
+					value={coordinates[0] === 0 && coordinates[1] === 0 ? '' : coordinates[0]}
+					onChange={(val) => {
+						const newLat = Number(val);
+						if (!isNaN(newLat)) {
+							updateCoordinates([newLat, coordinates[1]]);
+						}
+					}}
+				/>
+				{/* Longitude input */}
+				<NumberInput
+					key="lon"
+					disabled={disabled}
+					onBlur={() => handleBlur(1)}
+					onPaste={handlePaste}
+					placeholder="Longitude (-180 to 180)"
+					step={0.000001}
+					style={{ flex: 1 }}
+					value={coordinates[0] === 0 && coordinates[1] === 0 ? '' : coordinates[1]}
+					onChange={(val) => {
+						const newLng = Number(val);
+						if (!isNaN(newLng)) {
+							updateCoordinates([coordinates[0], newLng]);
+						}
+					}}
+				/>
+			</Section>
+		</Section>
 	);
 }


### PR DESCRIPTION
## Summary

Collection of small fixes and refactors across the alerts frontend, shared UI, API, and tooling. Aims to correct rendering edge cases, clarify loading behavior for alert detail, improve coordinate input UX, align hook/component naming with ESLint, and trim unnecessary agency payload fields.

## Changes

### Backend
- **Agencies controller** — Exclude `validation_rules` from agency data retrieval to avoid sending unused or sensitive validation metadata when it is not needed.

### Frontend — Alerts & detail
- **Alert detail** — Add a `key` on `AlertDetailHeader` so the header remounts correctly when navigating between alerts.
- **Alert detail context** — Simplify loading: stop folding alert image fetch into `isLoading` and remove redundant image-loading state so “loading” reflects core alert data more accurately.
- **Alerts list** — Add a `key` on `AlertsListContextProvider` for consistent re-rendering when list identity or route context changes.

### Frontend — Shared components
- **CoordinatesInput** — Rework state handling; support paste for lat/lon; clearer props; support both controlled and uncontrolled usage.

### Tooling & dependencies
- **ESLint** — Relax `@typescript-eslint/no-floating-promises` in the promises config where strict handling was too noisy.
- **ESLint** — Enforce naming: `camelCase` for React hooks and `PascalCase` for components.
- **Dependencies** — Bump `react-i18next` to `16.6.6` for i18n.

## Testing

- [ ] Smoke: open alert list → open an alert → switch alerts (header/detail update correctly).
- [ ] Coordinates field: typing, paste, controlled vs uncontrolled if both are used.
- [ ] Agencies endpoint: response shape matches consumers (no reliance on `validation_rules` in this path).