### PR TITLE
Refactor/clickhouse-single-node

### DIFF
--- a/infra/clickhouse/prd/terraform/templates/cloud-init.yaml
+++ b/infra/clickhouse/prd/terraform/templates/cloud-init.yaml
@@ -6,9 +6,6 @@
 # Docker and OS tuning are pre-baked into the Packer image.
 # This file handles runtime concerns only:
 #   - Attaches and mounts the 1TB block volume
-#   - Writes ClickHouse Keeper config (embedded keeper, 3-node Raft quorum)
-#   - Writes ZooKeeper client config (points CH to keeper endpoints)
-#   - Writes replica macros and cluster config
 #   - Writes secrets and starts the container
 #
 # Terraform variables injected:
@@ -54,101 +51,8 @@ runcmd:
     cat > /opt/app/persistent-data/config.d/network.xml <<'NETEOF'
     <clickhouse>
         <listen_host>0.0.0.0</listen_host>
-        <interserver_http_host>${all_private_ips[node_index]}</interserver_http_host>
     </clickhouse>
     NETEOF
-
-  # 5.
-  # ZooKeeper Client Config (replicated 3-node Keeper cluster)
-  # Points ClickHouse at all 3 Keeper nodes for high availability.
-  # If a Keeper node is down, ClickHouse will automatically failover
-  # to the next available node.
-
-  - |
-    cat > /opt/app/persistent-data/config.d/keeper.xml <<'KEEPEREOF'
-    <clickhouse>
-        <keeper_server>
-            <!-- ZooKeeper-compatible client port -->
-            <tcp_port>2181</tcp_port>
-            <!-- Unique server ID for this node (1, 2, or 3) -->
-            <server_id>${node_index + 1}</server_id>
-            <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-            <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-            <coordination_settings>
-                <operation_timeout_ms>10000</operation_timeout_ms>
-                <session_timeout_ms>30000</session_timeout_ms>
-                <raft_logs_level>warning</raft_logs_level>
-            </coordination_settings>
-            <raft_configuration>
-            %{ for idx in range(length(all_private_ips)) ~}
-                <server>
-                    <id>${idx + 1}</id>
-                    <hostname>${all_private_ips[idx]}</hostname>
-                    <!-- Inter-keeper Raft port -->
-                    <port>9444</port>
-                </server>
-            %{ endfor ~}
-            </raft_configuration>
-        </keeper_server>
-    </clickhouse>
-    KEEPEREOF
-
-  # 6.
-  # ZooKeeper Client Config — points ClickHouse at all 3 Keeper nodes
-  # Points ClickHouse at all 3 Keeper nodes for high availability.
-  # If a Keeper node is down, ClickHouse will automatically failover
-  # to the next available node.
-
-  - |
-    cat > /opt/app/persistent-data/config.d/zookeeper.xml <<'ZKEOF'
-    <clickhouse>
-        <zookeeper>
-        %{ for node_ip in all_private_ips ~}
-            <node>
-                <host>${node_ip}</host>
-                <port>2181</port>
-            </node>
-        %{ endfor ~}
-        </zookeeper>
-    </clickhouse>
-    ZKEOF
-
-  # 7.
-  # Replica Macros
-  # node-specific identity for ReplicatedMergeTree
-
-  - |
-    cat > /opt/app/persistent-data/config.d/macros.xml <<'MACROEOF'
-    <clickhouse>
-        <macros>
-            <shard>01</shard>
-            <replica>replica-${node_index + 1}</replica>
-            <cluster>default_cluster</cluster>
-        </macros>
-    </clickhouse>
-    MACROEOF
-
-  # 8.
-  # Cluster Config — all 3 replicas in one shard (no sharding)
-
-  - |
-    cat > /opt/app/persistent-data/config.d/cluster.xml <<'CLUSTEREOF'
-    <clickhouse>
-        <remote_servers>
-            <default_cluster>
-                <shard>
-                %{ for ip in all_private_ips ~}
-                  <replica>
-                      <host>${ip}</host>
-                      <port>${clickhouse_tcp_port}</port>
-                  </replica>
-                %{ endfor ~}
-                  <internal_replication>true</internal_replication>
-                </shard>
-            </default_cluster>
-        </remote_servers>
-    </clickhouse>
-    CLUSTEREOF
 
   # 9.
   # Performance Tuning Config (server-level)

--- a/infra/clickhouse/stg/terraform/templates/cloud-init.yaml
+++ b/infra/clickhouse/stg/terraform/templates/cloud-init.yaml
@@ -6,9 +6,6 @@
 # Docker and OS tuning are pre-baked into the Packer image.
 # This file handles runtime concerns only:
 #   - Attaches and mounts the 1TB block volume
-#   - Writes ClickHouse Keeper config (embedded keeper, 3-node Raft quorum)
-#   - Writes ZooKeeper client config (points CH to keeper endpoints)
-#   - Writes replica macros and cluster config
 #   - Writes secrets and starts the container
 #
 # Terraform variables injected:
@@ -54,101 +51,8 @@ runcmd:
     cat > /opt/app/persistent-data/config.d/network.xml <<'NETEOF'
     <clickhouse>
         <listen_host>0.0.0.0</listen_host>
-        <interserver_http_host>${all_private_ips[node_index]}</interserver_http_host>
     </clickhouse>
     NETEOF
-
-  # 5.
-  # ZooKeeper Client Config (replicated 3-node Keeper cluster)
-  # Points ClickHouse at all 3 Keeper nodes for high availability.
-  # If a Keeper node is down, ClickHouse will automatically failover
-  # to the next available node.
-
-  - |
-    cat > /opt/app/persistent-data/config.d/keeper.xml <<'KEEPEREOF'
-    <clickhouse>
-        <keeper_server>
-            <!-- ZooKeeper-compatible client port -->
-            <tcp_port>2181</tcp_port>
-            <!-- Unique server ID for this node (1, 2, or 3) -->
-            <server_id>${node_index + 1}</server_id>
-            <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-            <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-            <coordination_settings>
-                <operation_timeout_ms>10000</operation_timeout_ms>
-                <session_timeout_ms>30000</session_timeout_ms>
-                <raft_logs_level>warning</raft_logs_level>
-            </coordination_settings>
-            <raft_configuration>
-            %{ for idx in range(length(all_private_ips)) ~}
-                <server>
-                    <id>${idx + 1}</id>
-                    <hostname>${all_private_ips[idx]}</hostname>
-                    <!-- Inter-keeper Raft port -->
-                    <port>9444</port>
-                </server>
-            %{ endfor ~}
-            </raft_configuration>
-        </keeper_server>
-    </clickhouse>
-    KEEPEREOF
-
-  # 6.
-  # ZooKeeper Client Config — points ClickHouse at all 3 Keeper nodes
-  # Points ClickHouse at all 3 Keeper nodes for high availability.
-  # If a Keeper node is down, ClickHouse will automatically failover
-  # to the next available node.
-
-  - |
-    cat > /opt/app/persistent-data/config.d/zookeeper.xml <<'ZKEOF'
-    <clickhouse>
-        <zookeeper>
-        %{ for node_ip in all_private_ips ~}
-            <node>
-                <host>${node_ip}</host>
-                <port>2181</port>
-            </node>
-        %{ endfor ~}
-        </zookeeper>
-    </clickhouse>
-    ZKEOF
-
-  # 7.
-  # Replica Macros
-  # node-specific identity for ReplicatedMergeTree
-
-  - |
-    cat > /opt/app/persistent-data/config.d/macros.xml <<'MACROEOF'
-    <clickhouse>
-        <macros>
-            <shard>01</shard>
-            <replica>replica-${node_index + 1}</replica>
-            <cluster>default_cluster</cluster>
-        </macros>
-    </clickhouse>
-    MACROEOF
-
-  # 8.
-  # Cluster Config — all 3 replicas in one shard (no sharding)
-
-  - |
-    cat > /opt/app/persistent-data/config.d/cluster.xml <<'CLUSTEREOF'
-    <clickhouse>
-        <remote_servers>
-            <default_cluster>
-                <shard>
-                %{ for ip in all_private_ips ~}
-                  <replica>
-                      <host>${ip}</host>
-                      <port>${clickhouse_tcp_port}</port>
-                  </replica>
-                %{ endfor ~}
-                  <internal_replication>true</internal_replication>
-                </shard>
-            </default_cluster>
-        </remote_servers>
-    </clickhouse>
-    CLUSTEREOF
 
   # 9.
   # Performance Tuning Config (server-level)

--- a/packages/databases/src/templates/clickhouse.ts
+++ b/packages/databases/src/templates/clickhouse.ts
@@ -17,7 +17,7 @@ export abstract class ClickHouseInterfaceTemplate<T> {
 	protected readonly abstract schema: ClickHouseSchema<T>;
 	protected readonly abstract tableName: string;
 
-	protected readonly engine: ClickHouseTableEngine = 'ReplicatedMergeTree';
+	protected readonly engine: ClickHouseTableEngine = 'MergeTree';
 	protected readonly orderBy: string = '_id';
 	protected readonly partitionBy: null | string = null;
 
@@ -218,7 +218,7 @@ export abstract class ClickHouseInterfaceTemplate<T> {
 		await this.ensureDatabase();
 		// Setup the full CREATE TABLE query
 		const createTableQuery = `
-			CREATE TABLE IF NOT EXISTS "${this.databaseName}"."${this.tableName}" ON CLUSTER default_cluster (
+			CREATE TABLE IF NOT EXISTS "${this.databaseName}"."${this.tableName}" (
 				${Object.entries<ClickHouseColumn>(this.schema).map(([key, column]) => `${key} ${column.type}`).join(', ')}
 			) ENGINE = ${this.getEngineString()}
 			${this.orderBy ? `ORDER BY ${this.orderBy}` : ''}
@@ -240,8 +240,8 @@ export abstract class ClickHouseInterfaceTemplate<T> {
 	 */
 	private getEngineString(): string {
 		switch (this.engine) {
-			case 'ReplicatedMergeTree':
-				return `ReplicatedMergeTree('/clickhouse/tables/{shard}/${this.databaseName}/${this.tableName}', '{replica}')`;
+			case 'MergeTree':
+				return `MergeTree()`;
 			default:
 				throw new Error(`CLICKHOUSE [${this.databaseName}/${this.tableName}]: Unsupported engine type: ${this.engine}`);
 		}

--- a/packages/databases/src/types/clickhouse/table-engines.ts
+++ b/packages/databases/src/types/clickhouse/table-engines.ts
@@ -2,6 +2,5 @@
  * Definition for allowed ClickHouse table engines.
  * Please avoid using other engines before consulting with the team
  * as ClickHouse has many engines with different features and limitations.
- * For example, only `ReplicatedMergeTree` supports automatic replication.
  */
-export type ClickHouseTableEngine = 'ReplicatedMergeTree';
+export type ClickHouseTableEngine = 'MergeTree';


### PR DESCRIPTION
This PR simplifies our ClickHouse setup by removing replication-specific configuration and standardizing on a single-node deployment model.

## What changed
- Replaced replicated table engine usage with MergeTree for table creation.
- Removed ClickHouse Keeper / ZooKeeper client configuration from cloud-init templates.
- Updated both staging and production ClickHouse infrastructure templates to align with single-instance operation.