### PR TITLE
Fix/alert-automatic-text-wrong-time

### DIFF
--- a/modules/alerts/apps/frontend/package.json
+++ b/modules/alerts/apps/frontend/package.json
@@ -16,6 +16,7 @@
 	"dependencies": {
 		"@tabler/icons-react": "3.41.0",
 		"@tmlmobilidade/consts": "*",
+		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/go-alerts-pckg-describe": "*",
 		"@tmlmobilidade/ui": "*",
 		"@tmlmobilidade/utils": "*",

--- a/modules/alerts/packages/describe/src/templates/placeholders.ts
+++ b/modules/alerts/packages/describe/src/templates/placeholders.ts
@@ -44,8 +44,7 @@ export const templatePlaceholderReplacements = {
 						: `na paragem ${stopNames[0]}`;
 
 					parts.push(`linha ${lineShortName} ${stopsPart}`);
-				}
-				else {
+				} else {
 					parts.push(`linha ${lineShortName}`);
 				}
 			}
@@ -99,7 +98,7 @@ export const templatePlaceholderReplacements = {
 			for (const [, group] of Object.entries(patternGroups).sort()) {
 				const rideStartTimes = group
 					.sort((a, b) => a.start_time_scheduled - b.start_time_scheduled)
-					.map(ride => Dates.fromUnixTimestamp(ride.start_time_scheduled).setZone('Europe/Lisbon', 'rebase_utc').toFormat('HH:mm'));
+					.map(ride => Dates.fromUnixTimestamp(ride.start_time_scheduled).setZone('Europe/Lisbon', 'offset_only').toFormat('HH:mm'));
 
 				const lineShortNames = Array.from(new Set(group.map(ht => ht.line_id)));
 				const linePart = lineShortNames.length > 1
@@ -154,8 +153,7 @@ export const templatePlaceholderReplacements = {
 						: `da linha ${lineShortNames[0]}`;
 
 					parts.push(`paragem ${stopName} ${linesPart}`);
-				}
-				else {
+				} else {
 					parts.push(`paragem ${stopName}`);
 				}
 			}


### PR DESCRIPTION
## Summary


This PR fixes incorrect time rendering in automatic alert text generation for rides.

- Updates alert placeholder time formatting to use the correct Lisbon timezone conversion strategy (`offset_only`) so rendered ride times match expected local time.

- Adds `@tmlmobilidade/dates` to the alerts frontend dependencies to ensure the date utilities used by the feature are available.

## Why


Alert messages were showing wrong times in some cases due to timezone conversion mode, which could mislead riders/operators. This change aligns generated text with expected local schedule times.