### PR TITLE
Fix/Handle table-creation permission errors when table already exists

### DIFF
--- a/packages/databases/src/clients/go-clickhouse.ts
+++ b/packages/databases/src/clients/go-clickhouse.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { ClickHouseClient, createClient } from '@clickhouse/client';
+import { ClickHouseClient, ClickHouseLogLevel, createClient } from '@clickhouse/client';
 import { Logger } from '@tmlmobilidade/logger';
 import { type SshConfig, SshTunnelService, type SshTunnelServiceOptions } from '@tmlmobilidade/ssh';
 import { readFileSync } from 'node:fs';
@@ -53,6 +53,10 @@ export class GOClickHouseClient {
 		const connectionString = await this.getConnectionString();
 		this.client = createClient({
 			keep_alive: { enabled: false },
+			log: {
+				level: ClickHouseLogLevel.OFF,
+			},
+			request_timeout: 360 * 1000,
 			url: connectionString,
 		});
 	}

--- a/packages/databases/src/templates/clickhouse.ts
+++ b/packages/databases/src/templates/clickhouse.ts
@@ -5,7 +5,7 @@ import { preparePositionalQueryParams } from '@/utils/clickhouse/prepare-positio
 import { queryFromFile } from '@/utils/clickhouse/query-from-file.js';
 import { queryFromString } from '@/utils/clickhouse/query-from-string.js';
 import { validateSqlParam } from '@/utils/clickhouse/validate-sql-param.js';
-import { type ClickHouseClient, type DataFormat } from '@clickhouse/client';
+import { type ClickHouseClient, ClickHouseError, type DataFormat } from '@clickhouse/client';
 import { Logger } from '@tmlmobilidade/logger';
 
 /* * */
@@ -229,8 +229,30 @@ export abstract class ClickHouseInterfaceTemplate<T extends object> {
 			await this.client.command({ query: createTableQuery });
 			Logger.info(`CLICKHOUSE [${this.tableName}]: Table created.`);
 		} catch (error) {
-			Logger.error(`CLICKHOUSE [${this.tableName}]: Error @ createTable(): ${(error as Error).message}`);
-			throw error;
+			// If the error is not an ACCESS_DENIED, throw it right away
+			if (!(error instanceof ClickHouseError) || error.type !== 'ACCESS_DENIED') {
+				Logger.error(`CLICKHOUSE [${this.tableName}]: Error @ createTable(): ${(error as Error).message}`);
+				throw error;
+			}
+
+			// If the error is an ACCESS_DENIED, check if the table exists
+			try {
+				const tables = await this.client.query({
+					format: 'JSONEachRow',
+					query: `SHOW TABLES FROM "${this.databaseName}" LIKE '${this.tableName}'`,
+				});
+
+				const tableExists = Array.isArray(tables) ? tables.length > 0 : Boolean(tables);
+				if (tableExists) return;
+
+				Logger.error(`CLICKHOUSE [${this.tableName}]: ACCESS_DENIED and table does not exist. ${error.message}`);
+				throw error;
+			} catch (verifyError) {
+				//
+
+				Logger.error(`CLICKHOUSE [${this.tableName}]: Failed to verify table existence after ACCESS_DENIED: ${(verifyError as Error).message}`);
+				throw verifyError;
+			}
 		}
 	}
 

--- a/packages/databases/src/templates/clickhouse.ts
+++ b/packages/databases/src/templates/clickhouse.ts
@@ -237,13 +237,12 @@ export abstract class ClickHouseInterfaceTemplate<T extends object> {
 
 			// If the error is an ACCESS_DENIED, check if the table exists
 			try {
-				const tables = await this.client.query({
+				const resultSet = await this.client.query({
 					format: 'JSONEachRow',
 					query: `SHOW TABLES FROM "${this.databaseName}" LIKE '${this.tableName}'`,
 				});
-
-				const tableExists = Array.isArray(tables) ? tables.length > 0 : Boolean(tables);
-				if (tableExists) return;
+				const tables = await resultSet.json();
+				if (Array.isArray(tables) && tables.length > 0) return;
 
 				Logger.error(`CLICKHOUSE [${this.tableName}]: ACCESS_DENIED and table does not exist. ${error.message}`);
 				throw error;

--- a/packages/databases/src/templates/clickhouse.ts
+++ b/packages/databases/src/templates/clickhouse.ts
@@ -230,7 +230,7 @@ export abstract class ClickHouseInterfaceTemplate<T extends object> {
 			Logger.info(`CLICKHOUSE [${this.tableName}]: Table created.`);
 		} catch (error) {
 			// If the error is not an ACCESS_DENIED, throw it right away
-			if (!(error instanceof ClickHouseError) || error.type !== 'ACCESS_DENIED') {
+			if (!(error instanceof ClickHouseError) || error.code !== '497') {
 				Logger.error(`CLICKHOUSE [${this.tableName}]: Error @ createTable(): ${(error as Error).message}`);
 				throw error;
 			}


### PR DESCRIPTION
## Why

Some users cannot run `CREATE TABLE` due to ClickHouse permissions, but ingestion should still work if the target table is already present.

## What changed

- In `GOClickHouseClient`, set *ClickHouse* client config to:
  - disable logs (ClickHouseLogLevel.OFF)
  - increase request timeout (360000ms)
- In `ClickHouseInterfaceTemplate.createTable()`:
  - keep throwing for non-ACCESS_DENIED errors
  - when error is ACCESS_DENIED, verify whether table already exists via SHOW TABLES
  - if table exists, continue without throwing
  - if table does not exist (or verification fails), log and throw
 
## Outcome

Prevents false failures for users without create privileges when table already exists, while still surfacing real setup/permission issues when table is missing.