### PR TITLE
Refactor/export-nuqs-functions-from-@tmlmobilidade/ui

### DIFF
--- a/modules/auth/apps/frontend/src/components/agencies/list/AgenciesList.context.tsx
+++ b/modules/auth/apps/frontend/src/components/agencies/list/AgenciesList.context.tsx
@@ -5,8 +5,7 @@
 import { useAgenciesContext } from '@/contexts/Agencies.context';
 import { type AgencyNormalized } from '@/types/normalized';
 import { normalizeString } from '@tmlmobilidade/strings';
-import { useSearch } from '@tmlmobilidade/ui';
-import { useQueryState } from 'nuqs';
+import { useQueryState, useSearch } from '@tmlmobilidade/ui';
 import { createContext, type PropsWithChildren, useContext, useMemo } from 'react';
 
 /* * */

--- a/modules/auth/apps/frontend/src/components/auth/ChangePasswordForm/index.tsx
+++ b/modules/auth/apps/frontend/src/components/auth/ChangePasswordForm/index.tsx
@@ -7,11 +7,10 @@ import { IconCheck, IconX } from '@tabler/icons-react';
 import { API_ROUTES, PAGE_ROUTES } from '@tmlmobilidade/consts';
 import { PasswordRequirementsSchema } from '@tmlmobilidade/types';
 import { Session } from '@tmlmobilidade/types';
-import { PasswordInput } from '@tmlmobilidade/ui';
+import { PasswordInput, useQueryState } from '@tmlmobilidade/ui';
 import { useToast } from '@tmlmobilidade/ui';
 import { fetchData } from '@tmlmobilidade/utils';
 import bcrypt from 'bcryptjs';
-import { useQueryState } from 'nuqs';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/modules/auth/apps/frontend/src/components/auth/LoginForm/index.tsx
+++ b/modules/auth/apps/frontend/src/components/auth/LoginForm/index.tsx
@@ -5,9 +5,8 @@
 import { AuthenticationForm } from '@/components/common/AuthenticationForm';
 import { API_ROUTES, PAGE_ROUTES } from '@tmlmobilidade/consts';
 import { Session } from '@tmlmobilidade/types';
-import { PasswordInput, TextInput, useToast } from '@tmlmobilidade/ui';
+import { PasswordInput, TextInput, useQueryState, useToast } from '@tmlmobilidade/ui';
 import { fetchData } from '@tmlmobilidade/utils';
-import { useQueryState } from 'nuqs';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/modules/auth/apps/frontend/src/components/auth/SendPasswordResetEmailForm/index.tsx
+++ b/modules/auth/apps/frontend/src/components/auth/SendPasswordResetEmailForm/index.tsx
@@ -5,9 +5,8 @@
 import { AuthenticationForm } from '@/components/common/AuthenticationForm';
 import { API_ROUTES, PAGE_ROUTES } from '@tmlmobilidade/consts';
 import { Session } from '@tmlmobilidade/types';
-import { TextInput, useToast } from '@tmlmobilidade/ui';
+import { TextInput, useQueryState, useToast } from '@tmlmobilidade/ui';
 import { fetchData } from '@tmlmobilidade/utils';
-import { useQueryState } from 'nuqs';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/modules/auth/apps/frontend/src/components/organizations/list/OrganizationsList.context.tsx
+++ b/modules/auth/apps/frontend/src/components/organizations/list/OrganizationsList.context.tsx
@@ -5,8 +5,7 @@
 import { useOrganizationsContext } from '@/contexts/Organizations.context';
 import { type OrganizationNormalized } from '@/types/normalized';
 import { normalizeString } from '@tmlmobilidade/strings';
-import { useSearch } from '@tmlmobilidade/ui';
-import { useQueryState } from 'nuqs';
+import { useQueryState, useSearch } from '@tmlmobilidade/ui';
 import { createContext, type PropsWithChildren, useContext, useMemo } from 'react';
 
 /* * */

--- a/modules/auth/apps/frontend/src/components/roles/list/RolesList.context.tsx
+++ b/modules/auth/apps/frontend/src/components/roles/list/RolesList.context.tsx
@@ -5,8 +5,7 @@
 import { useRolesContext } from '@/contexts/Roles.context';
 import { type RoleNormalized } from '@/types/normalized';
 import { normalizeString } from '@tmlmobilidade/strings';
-import { useSearch } from '@tmlmobilidade/ui';
-import { useQueryState } from 'nuqs';
+import { useQueryState, useSearch } from '@tmlmobilidade/ui';
 import { createContext, type PropsWithChildren, useContext, useMemo } from 'react';
 
 /* * */

--- a/modules/auth/apps/frontend/src/components/users/list/UsersList.context.tsx
+++ b/modules/auth/apps/frontend/src/components/users/list/UsersList.context.tsx
@@ -8,8 +8,7 @@ import { type UserNormalized } from '@/types/normalized';
 import { API_ROUTES } from '@tmlmobilidade/consts';
 import { normalizeString } from '@tmlmobilidade/strings';
 import { type User } from '@tmlmobilidade/types';
-import { parseAsArrayOfStrings, useSearch } from '@tmlmobilidade/ui';
-import { useQueryState } from 'nuqs';
+import { parseAsArrayOfStrings, useQueryState, useSearch } from '@tmlmobilidade/ui';
 import { createContext, PropsWithChildren, useContext, useMemo } from 'react';
 import useSWR from 'swr';
 

--- a/modules/controller/apps/frontend/src/components/rides/list/RidesList.context.tsx
+++ b/modules/controller/apps/frontend/src/components/rides/list/RidesList.context.tsx
@@ -3,14 +3,12 @@
 /* * */
 
 import { useRideFavoritesContext } from '@/contexts/RideFavorites.context';
-import { useDebouncedValue } from '@mantine/hooks';
 import { API_ROUTES } from '@tmlmobilidade/consts';
 import { Dates } from '@tmlmobilidade/dates';
 import { type OperationalStatus, PermissionCatalog, type RideNormalized, RideNormalizedSchema } from '@tmlmobilidade/types';
 import { DelayStatusSchema, OperationalStatusSchema } from '@tmlmobilidade/types';
 import { RIDE_ANALYSIS_GRADE_OPTIONS, type UnixTimestamp } from '@tmlmobilidade/types';
-import { useDataAgencies, useDataRides, useFilterStateList, type UseFilterStateListReturnType, useFilterStateString, type UseFilterStateStringReturnType } from '@tmlmobilidade/ui';
-import { parseAsInteger, useQueryState } from 'nuqs';
+import { parseAsInteger, useDataAgencies, useDataRides, useDebouncedValue, useFilterStateList, type UseFilterStateListReturnType, useFilterStateString, type UseFilterStateStringReturnType, useQueryState } from '@tmlmobilidade/ui';
 import { createContext, type PropsWithChildren, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/modules/performance/apps/frontend/src/contexts/Locale.context.tsx
+++ b/modules/performance/apps/frontend/src/contexts/Locale.context.tsx
@@ -3,9 +3,8 @@
 /* * */
 
 import { availableFormats, DEFAULT_LOCALE_CODE, defaultLocale, enabledLocales, getMatchingLocale, LOCALE_STORAGE_KEY } from '@/i18n/config';
-import { useLocalStorage } from '@mantine/hooks';
+import { useLocalStorage, useQueryState } from '@tmlmobilidade/ui';
 import { NextIntlClientProvider } from 'next-intl';
-import { useQueryState } from 'nuqs';
 import { createContext, useContext, useEffect, useMemo } from 'react';
 
 /* * */

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -9,3 +9,4 @@ export * from './src/utils';
 export * from '@mantine/charts';
 export * from '@mantine/form';
 export { zod4Resolver, zodResolver } from 'mantine-form-zod-resolver';
+export { createParser, parseAsBoolean, parseAsFloat, parseAsHex, parseAsIndex, parseAsInteger, parseAsIsoDate, parseAsIsoDateTime, parseAsString, parseAsTimestamp, useQueryState } from 'nuqs';


### PR DESCRIPTION
Consolidates `nuqs` usage behind `@tmlmobilidade/ui`.