### PR TITLE
feat: add timezone-aware DateTimeInput and use it in date range filter

### DIFF
--- a/packages/ui/src/components/dates/DateTimeInput/index.tsx
+++ b/packages/ui/src/components/dates/DateTimeInput/index.tsx
@@ -5,7 +5,7 @@
 import { Fieldset, Input } from '@mantine/core';
 import { DateInput as MantineDateInput, TimePicker as MantineTimePicker } from '@mantine/dates';
 import { IconCalendar, IconClock } from '@tabler/icons-react';
-import { Dates } from '@tmlmobilidade/dates';
+import { Dates, TimezoneIdentified } from '@tmlmobilidade/dates';
 import { type UnixTimestamp, validateUnixTimestamp } from '@tmlmobilidade/types';
 import { useEffect, useState } from 'react';
 
@@ -68,6 +68,12 @@ export interface DateTimeInputProps {
 	readOnly?: boolean
 
 	/**
+	 * Timezone to use for the input.
+	 * @default 'Europe/Lisbon'
+	 */
+	timezone?: TimezoneIdentified
+
+	/**
 	 * The value of the input.
 	 * Use this field for controlled components.
 	 * @default null
@@ -92,6 +98,7 @@ export function DateTimeInput(props: DateTimeInputProps) {
 
 	const [dateInputValue, setDateInputValue] = useState<string>();
 	const [timePickerValue, setTimePickerValue] = useState<string>();
+	const timezone = props.timezone ?? 'Europe/Lisbon';
 
 	//
 	// B. Transform data
@@ -111,15 +118,16 @@ export function DateTimeInput(props: DateTimeInputProps) {
 			// Transform unix timestamp into date and time strings
 			const dateString = Dates
 				.fromUnixTimestamp(validatedUnixTimestamp)
+				.setZone(timezone, 'offset_only')
 				.toFormat('yyyy-MM-dd');
 			setDateInputValue(dateString);
 			// Transform unix timestamp into time string
 			const timeString = Dates
 				.fromUnixTimestamp(validatedUnixTimestamp)
+				.setZone(timezone, 'offset_only')
 				.toFormat('HH:mm:ss');
 			setTimePickerValue(timeString);
-		}
-		catch (error) {
+		} catch (error) {
 			console.error('DateInput: Invalid unix timestamp provided in value prop', error);
 			setDateInputValue(undefined);
 			setTimePickerValue(undefined);
@@ -138,17 +146,16 @@ export function DateTimeInput(props: DateTimeInputProps) {
 		try {
 			const formattedTimeValue = timePickerValue.length === 5 ? `${timePickerValue}:00` : timePickerValue;
 			const unixTimestamp = Dates
-				.fromFormat(`${dateInputValue} ${formattedTimeValue}`, 'yyyy-MM-dd HH:mm:ss', 'utc')
+				.fromFormat(`${dateInputValue} ${formattedTimeValue}`, 'yyyy-MM-dd HH:mm:ss', timezone)
 				.unix_timestamp;
 			const validatedUnixTimestamp = validateUnixTimestamp(unixTimestamp);
 			props.onChange(validatedUnixTimestamp);
 			return;
-		}
-		catch (error) {
+		} catch (error) {
 			console.log('DateTimeInput: Invalid date format', error);
 			return;
 		}
-	}, [dateInputValue, timePickerValue]);
+	}, [dateInputValue, timePickerValue, props.onChange, timezone]);
 
 	//
 	// C. Render components

--- a/packages/ui/src/components/dates/DateTimeInput/index.tsx
+++ b/packages/ui/src/components/dates/DateTimeInput/index.tsx
@@ -155,7 +155,7 @@ export function DateTimeInput(props: DateTimeInputProps) {
 			console.log('DateTimeInput: Invalid date format', error);
 			return;
 		}
-	}, [dateInputValue, timePickerValue, props.onChange, timezone]);
+	}, [dateInputValue, timePickerValue, props.onChange, timezone, props.value]);
 
 	//
 	// C. Render components

--- a/packages/ui/src/components/filters/FilterTypeDateRange/index.tsx
+++ b/packages/ui/src/components/filters/FilterTypeDateRange/index.tsx
@@ -2,7 +2,7 @@
 
 import { type UnixTimestamp } from '@tmlmobilidade/types';
 
-import { DateTimePicker } from '../../dates/DateTimePicker';
+import { DateTimeInput } from '../../dates/DateTimeInput';
 import { Label } from '../../display/Label';
 import { Section } from '../../layout/Section';
 import { Spacer } from '../../layout/Spacer';
@@ -31,14 +31,13 @@ export function FilterTypeDateRange({ active, disabled, endDate, label, onEndDat
 		>
 			<Section gap="sm" height="auto" padding="md"width="auto">
 				<Label size="md">Data de Início</Label>
-				<DateTimePicker
+				<DateTimeInput
 					onChange={onStartDateChange}
 					value={startDate}
-					fullWidth
 				/>
 				<Spacer />
 				<Label size="md">Data de Fim</Label>
-				<DateTimePicker
+				<DateTimeInput
 					onChange={onEndDateChange}
 					value={endDate}
 


### PR DESCRIPTION
## Summary
- Adds optional timezone prop to `DateTimeInput` (default: Europe/Lisbon) to make timestamp parsing/formatting explicit and consistent.
- Updates display formatting to apply selected timezone before rendering date/time values.
- Updates value parsing to use selected timezone when converting input back to Unix timestamp.
- Replaces `DateTimePicker` with `DateTimeInput` in `FilterTypeDateRange` for start/end date fields.