### PR TITLE
fix/update initial publish status assignment in getPublishStatus function

### DIFF
--- a/modules/alerts/packages/organize/src/functions/get-publish-status.ts
+++ b/modules/alerts/packages/organize/src/functions/get-publish-status.ts
@@ -23,7 +23,7 @@ export function getPublishStatus(alertData: Alert): PublishStatus {
 	// Check the active period and publish period
 	// to determine if the alert should be published
 
-	let result: PublishStatus = 'draft';
+	let result: PublishStatus = alertData.publish_status;
 
 	const nowUnixTimestamp = Dates.now('Europe/Lisbon').unix_timestamp;
 

--- a/modules/alerts/packages/organize/src/functions/get-publish-status.ts
+++ b/modules/alerts/packages/organize/src/functions/get-publish-status.ts
@@ -39,8 +39,7 @@ export function getPublishStatus(alertData: Alert): PublishStatus {
 	}
 
 	//
-	// If the alert does not match any known publish status,
-	// return 'draft' as a fallback.
+	// Return the determined publish status
 
 	return result;
 }


### PR DESCRIPTION
## Summary

Fixes derived publish status for non-draft alerts whose `publish_start_date` is still in the future.

## Problem

`getPublishStatus` initialized the working value as `'draft'` for every alert that was not an early-return draft. It only flipped to `'published'` when `publish_start_date` existed and was `<= now`.

So an alert already stored as `published` but with a `publish_start_date` in the future never satisfied that condition. The function kept returning draft, overwriting the real stored status.

## Solution

Initialize the computed status from `alertData.publish_status` instead of `'draft'`. Date rules still promote to published once the start time is reached and to archived after the end time; draft alerts are unchanged (still short-circuited when `publish_status === 'draft'`).