### PR TITLE
feat(tracker): ingest CP (Comboios de Portugal) GTFS-RT vehicle positions

### DIFF
--- a/modules/tracker/apps/cp-fetch/eslint.config.mjs
+++ b/modules/tracker/apps/cp-fetch/eslint.config.mjs
@@ -1,0 +1,9 @@
+/* * */
+
+import { node } from '@tmlmobilidade/eslint'
+
+/* * */
+
+export default [
+  ...node,
+]

--- a/modules/tracker/apps/cp-fetch/package.json
+++ b/modules/tracker/apps/cp-fetch/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "@tmlmobilidade/go-tracker-cp-fetch",
+	"version": "1.0.0",
+	"author": {
+		"email": "iso@tmlmobilidade.pt",
+		"name": "TML-ISO"
+	},
+	"license": "AGPL-3.0-or-later",
+	"type": "module",
+	"files": ["dist"],
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "tsc && resolve-tspaths",
+		"dev": "tsx watch src/index.ts",
+		"lint": "eslint . --fix && tsc --noEmit",
+		"lint:fix": "eslint . --fix"
+	},
+	"dependencies": {
+		"@tmlmobilidade/databases": "*",
+		"@tmlmobilidade/dates": "*",
+		"@tmlmobilidade/go-tracker-pckg-shared": "*",
+		"@tmlmobilidade/gtfs-rt": "*",
+		"@tmlmobilidade/logger": "*",
+		"@tmlmobilidade/timer": "*",
+		"@tmlmobilidade/types": "*",
+		"@tmlmobilidade/utils": "*"
+	},
+	"devDependencies": {
+		"@tmlmobilidade/tsconfig": "*",
+		"@types/node": "25.8.0",
+		"resolve-tspaths": "0.8.23",
+		"tsx": "4.22.1",
+		"typescript": "5.9.3"
+	}
+}

--- a/modules/tracker/apps/cp-fetch/src/index.ts
+++ b/modules/tracker/apps/cp-fetch/src/index.ts
@@ -1,0 +1,149 @@
+/* * */
+
+import { rawVehicleEventsNew } from '@tmlmobilidade/databases';
+import { Dates } from '@tmlmobilidade/dates';
+import { decodeGtfsRtFeed } from '@tmlmobilidade/gtfs-rt';
+import { Logger } from '@tmlmobilidade/logger';
+import { Timer } from '@tmlmobilidade/timer';
+import { type HashableRawVehicleEvent, type RawVehicleEventCpV1 } from '@tmlmobilidade/types';
+import { runOnInterval } from '@tmlmobilidade/utils';
+import crypto from 'node:crypto';
+
+/* * */
+
+const API_URL = 'https://api-gateway.cp.pt/cp/partner/gtfs-partners/realtime/VehiclePositions.pb';
+const API_TOKEN_URL = 'https://login-qua2.cp.pt/realms/api-auth/protocol/openid-connect/token';
+
+/* * */
+
+interface TokenResponse {
+	access_token: string
+	expires_in: number
+	refresh_token: string
+	scope: string
+	token_type: string
+}
+
+let ITERATION = 0;
+
+let API_TOKEN: TokenResponse | undefined = undefined;
+/* * */
+
+const main = async () => {
+	//
+
+	const timer = new Timer();
+
+	let saveCount = 0;
+
+	//
+	// Fetch the CP Vehicle Events data from the API and decode it
+
+	Logger.info(`[${ITERATION}] Fetching CP data from API...`, 0, 1);
+
+	if (!API_TOKEN || API_TOKEN.expires_in < Date.now()) {
+		const tokenResponse = await fetch(API_TOKEN_URL, {
+			body: new URLSearchParams({
+				client_id: process.env.CP_CLIENT_ID || '',
+				client_secret: process.env.CP_CLIENT_SECRET || '',
+				grant_type: 'client_credentials',
+			}),
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			method: 'POST',
+		});
+
+		const tokenResponseData = await tokenResponse.json() as TokenResponse;
+		API_TOKEN = {
+			access_token: tokenResponseData.access_token,
+			expires_in: (Dates.now('Europe/Lisbon').unix_timestamp + tokenResponseData.expires_in * 1000) - 5000, // 5 seconds before expiration
+			refresh_token: tokenResponseData.refresh_token,
+			scope: tokenResponseData.scope,
+			token_type: tokenResponseData.token_type,
+		};
+	}
+
+	const response = await fetch(API_URL, {
+		headers: {
+			'Authorization': `Bearer ${API_TOKEN.access_token}`,
+			'x-cp-connect-id': process.env.CP_API_KEY || '',
+			'x-cp-connect-secret': process.env.CP_API_SECRET || '',
+		},
+	});
+
+	const arrayBuffer = await response.arrayBuffer();
+	const decodedMessage = await decodeGtfsRtFeed(arrayBuffer);
+
+	Logger.info(`[${ITERATION}] Found ${decodedMessage.entity?.length ?? 0} Vehicle Events in the CP data.`);
+
+	//
+	// Transform each message into a RawVehicleEvent
+
+	for (const entity of decodedMessage.entity ?? []) {
+		//
+
+		//
+		// Skip entities that do not have a vehicle field,
+		// as they are not relevant for our use case.
+
+		if (!entity.vehicle) continue;
+
+		//
+		// Skip entities that do not have a trip field,
+		// as they are not relevant for our use case.
+
+		if (!entity.vehicle.trip) continue;
+
+		//
+		// Hash the relevant fields of the vehicle event
+		// to create a unique identifier for the event.
+		// This allows us to identify duplicate events
+		// and avoid storing them multiple times in the database.
+
+		const hashableRawEvent: HashableRawVehicleEvent<RawVehicleEventCpV1> = {
+			agency_id: '3',
+			created_at: Dates.fromSeconds(Number(entity.vehicle.timestamp)).unix_timestamp,
+			entity_id: entity.id,
+			payload: {
+				header: decodedMessage.header,
+				vehicle: entity.vehicle,
+
+			},
+			version: 'cp-v1',
+		};
+
+		const hashableRawEventId = crypto
+			.createHash('sha256')
+			.update(JSON.stringify(hashableRawEvent))
+			.digest('hex');
+
+		//
+		// Write the new vehicle event document
+		// to the RawVehicleEvents collection
+
+		const alreadyExists = await rawVehicleEventsNew.findOne({ _id: hashableRawEventId });
+
+		if (alreadyExists) continue;
+
+		await rawVehicleEventsNew.insertOne({
+			...hashableRawEvent,
+			_id: hashableRawEventId,
+			received_at: Dates.now('Europe/Lisbon').unix_timestamp,
+		});
+
+		saveCount++;
+
+		//
+	}
+
+	Logger.info(`[${ITERATION}] Saved ${saveCount} new Vehicle Events from CAP data in ${timer.get()}.`);
+
+	ITERATION++;
+
+	//
+};
+
+/* * */
+
+await runOnInterval(main, { intervalMs: '30s', throwOnError: true });

--- a/modules/tracker/apps/cp-fetch/tsconfig.json
+++ b/modules/tracker/apps/cp-fetch/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "@tmlmobilidade/tsconfig/nodejs.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/types/src/vehicle-events/raw/cp/index.ts
+++ b/packages/types/src/vehicle-events/raw/cp/index.ts
@@ -1,0 +1,1 @@
+export * from '@/vehicle-events/raw/cp/v1.js';

--- a/packages/types/src/vehicle-events/raw/cp/v1.ts
+++ b/packages/types/src/vehicle-events/raw/cp/v1.ts
@@ -1,0 +1,43 @@
+/* * */
+
+import { GtfsRtOccupancyStatusSchema } from '@/gtfs-rt/occupancy-status.js';
+import { RawVehicleEventBaseSchema } from '@/vehicle-events/raw/raw-vehicle-event-base.js';
+import { z } from 'zod';
+
+/* * */
+
+export const RawVehicleEventCpV1PayloadSchema = z.object({
+	header: z.object({
+		feed_version: z.string().nullish(),
+		gtfs_realtime_version: z.string(),
+		incrementality: z.literal('FULL_DATASET'),
+		timestamp: z.number(),
+	}),
+	vehicle: z.object({
+		current_status: z.enum(['INCOMING_AT', 'STOPPED_AT', 'IN_TRANSIT_TO']).nullish(),
+		occupancy_status: GtfsRtOccupancyStatusSchema.nullish(),
+		position: z.object({
+			latitude: z.number(),
+			longitude: z.number(),
+		}),
+		timestamp: z.number().nullish(),
+		trip: z.object({
+			schedule_relationship: z.enum(['SCHEDULED', 'NOT_SCHEDULED']).nullish(),
+			trip_id: z.string(),
+		}),
+		vehicle: z.object({
+			id: z.string(),
+		}),
+	}),
+});
+
+export type RawVehicleEventCpV1Payload = z.infer<typeof RawVehicleEventCpV1PayloadSchema>;
+
+/* * */
+
+export const RawVehicleEventCpV1Schema = RawVehicleEventBaseSchema.extend({
+	payload: RawVehicleEventCpV1PayloadSchema,
+	version: z.literal('cp-v1'),
+});
+
+export type RawVehicleEventCpV1 = z.infer<typeof RawVehicleEventCpV1Schema>;

--- a/packages/types/src/vehicle-events/raw/index.ts
+++ b/packages/types/src/vehicle-events/raw/index.ts
@@ -1,6 +1,7 @@
 export * from '@/vehicle-events/raw/cap/index.js';
 export * from '@/vehicle-events/raw/ccfl/index.js';
 export * from '@/vehicle-events/raw/cmet/index.js';
+export * from '@/vehicle-events/raw/cp/index.js';
 export * from '@/vehicle-events/raw/raw-vehicle-event-base.js';
 export * from '@/vehicle-events/raw/raw-vehicle-event.js';
 export * from '@/vehicle-events/raw/ttsl/index.js';

--- a/packages/types/src/vehicle-events/raw/raw-vehicle-event.ts
+++ b/packages/types/src/vehicle-events/raw/raw-vehicle-event.ts
@@ -4,6 +4,7 @@ import { RawVehicleEventCapV1Schema } from '@/vehicle-events/raw/cap/v1.js';
 import { RawVehicleEventCcflV1Schema } from '@/vehicle-events/raw/ccfl/v1.js';
 import { RawVehicleEventCmetV1CoreSchema } from '@/vehicle-events/raw/cmet/v1-core.js';
 import { RawVehicleEventCmetV1LogSchema } from '@/vehicle-events/raw/cmet/v1-log.js';
+import { RawVehicleEventCpV1Schema } from '@/vehicle-events/raw/cp/v1.js';
 import { RawVehicleEventTtslV1Schema } from '@/vehicle-events/raw/ttsl/v1.js';
 import { z } from 'zod';
 
@@ -15,6 +16,7 @@ export const RawVehicleEventSchema = z.discriminatedUnion('version', [
 	RawVehicleEventCmetV1CoreSchema,
 	RawVehicleEventCmetV1LogSchema,
 	RawVehicleEventTtslV1Schema,
+	RawVehicleEventCpV1Schema,
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Adds ingestion for **Comboios de Portugal (CP)** real-time vehicle positions into the tracker raw events pipeline.

- **New app** `@tmlmobilidade/go-tracker-cp-fetch` — polls CP’s GTFS-RT `VehiclePositions.pb` feed every 30s (same pattern as `cap-fetch`).
- **OAuth2 client credentials** — obtains and caches a bearer token from CP’s OpenID Connect endpoint; refreshes before expiry (5s buffer).
- **Raw event types** — introduces `RawVehicleEventCpV1` / `cp-v1` schema and registers it on the `RawVehicleEvent` discriminated union.
- **Persistence** — decodes the protobuf feed, maps entities with `vehicle` + `trip` to hashable events (`agency_id: '3'`), deduplicates via SHA-256 `_id`, and inserts new documents into `rawVehicleEventsNew`.

## Details

| Item | Value |
|------|--------|
| Version | `cp-v1` |
| Agency ID | `3` |
| Auth | `CP_CLIENT_ID`, `CP_CLIENT_SECRET` (token) + `CP_API_KEY`, `CP_API_SECRET` (API headers) |
| Token URL | `login-qua2.cp.pt` (CP QA realm) |