### PR TITLE
fix(ui): stabilize sidebar menu item rendering

### DIFF
--- a/modules/dates/apps/frontend/src/components/events/detail/EventsDetailPatternsMenu/index.tsx
+++ b/modules/dates/apps/frontend/src/components/events/detail/EventsDetailPatternsMenu/index.tsx
@@ -13,6 +13,20 @@ interface EventsDetailPatternsMenuProps {
 
 /* * */
 
+function EventsDetailPatternsMenuItem({ item: pattern }: { item: Event['associated_patterns'][number] }) {
+	return (
+		<MenuItem
+			description={pattern.headsign}
+			href={PAGE_ROUTES.offer.PATTERN_DETAIL(pattern.line_id, pattern._id, pattern.route_id)}
+			rel="noopener noreferrer"
+			target="_blank"
+			title={pattern.code}
+		/>
+	);
+}
+
+/* * */
+
 export function EventsDetailPatternsMenu({ patterns = [] }: EventsDetailPatternsMenuProps) {
 	return (
 		<Menu
@@ -30,17 +44,10 @@ export function EventsDetailPatternsMenu({ patterns = [] }: EventsDetailPatterns
 			) : (
 				<MenuList
 					data={patterns}
+					getItemKey={pattern => pattern._id}
+					itemComponent={EventsDetailPatternsMenuItem}
 					maxHeight={500}
 					title="Patterns associados"
-					itemComponent={({ item: pattern }) => (
-						<MenuItem
-							description={pattern.headsign}
-							href={PAGE_ROUTES.offer.PATTERN_DETAIL(pattern.line_id, pattern._id, pattern.route_id)}
-							rel="noopener noreferrer"
-							target="_blank"
-							title={pattern.code}
-						/>
-					)}
 				/>
 			)}
 		</Menu>

--- a/modules/stops/apps/frontend/src/components/stops/detail/StopDetailPatternsMenu/index.tsx
+++ b/modules/stops/apps/frontend/src/components/stops/detail/StopDetailPatternsMenu/index.tsx
@@ -13,6 +13,20 @@ interface StopDetailPatternsMenuProps {
 
 /* * */
 
+function StopDetailPatternsMenuItem({ item: pattern }: { item: Event['associated_patterns'][number] }) {
+	return (
+		<MenuItem
+			description={pattern.headsign}
+			href={PAGE_ROUTES.offer.PATTERN_DETAIL(pattern.line_id, pattern._id, pattern.route_id)}
+			rel="noopener noreferrer"
+			target="_blank"
+			title={pattern.code}
+		/>
+	);
+}
+
+/* * */
+
 export function StopDetailPatternsMenu({ patterns = [] }: StopDetailPatternsMenuProps) {
 	return (
 		<Menu
@@ -30,17 +44,10 @@ export function StopDetailPatternsMenu({ patterns = [] }: StopDetailPatternsMenu
 			) : (
 				<MenuList
 					data={patterns}
+					getItemKey={pattern => pattern._id}
+					itemComponent={StopDetailPatternsMenuItem}
 					maxHeight={500}
 					title="Patterns associados"
-					itemComponent={({ item: pattern }) => (
-						<MenuItem
-							description={pattern.headsign}
-							href={PAGE_ROUTES.offer.PATTERN_DETAIL(pattern.line_id, pattern._id, pattern.route_id)}
-							rel="noopener noreferrer"
-							target="_blank"
-							title={pattern.code}
-						/>
-					)}
 				/>
 			)}
 		</Menu>

--- a/packages/ui/src/components/menu/MenuList/index.tsx
+++ b/packages/ui/src/components/menu/MenuList/index.tsx
@@ -2,7 +2,7 @@
 
 /* * */
 
-import { createElement, useMemo, useState } from 'react';
+import { createElement, type Key, useMemo, useState } from 'react';
 
 import styles from './styles.module.css';
 
@@ -13,6 +13,7 @@ import { Section } from '../../layout/Section';
 
 interface MenuListProps<T> {
 	data: T[]
+	getItemKey: (item: T, index: number) => Key
 	itemComponent: React.ComponentType<{ item: T }>
 	maxDisplayedItems?: number
 	maxHeight?: number | string
@@ -21,7 +22,7 @@ interface MenuListProps<T> {
 
 /* * */
 
-export function MenuList<T>({ data, itemComponent, maxDisplayedItems, maxHeight = 300, title }: MenuListProps<T>) {
+export function MenuList<T>({ data, getItemKey, itemComponent, maxDisplayedItems, maxHeight = 300, title }: MenuListProps<T>) {
 	//
 
 	//
@@ -42,7 +43,7 @@ export function MenuList<T>({ data, itemComponent, maxDisplayedItems, maxHeight 
 		<Section flexDirection="column" gap="sm" maxHeight={maxHeight} overflow="scroll" padding="sm" width="100%">
 			<Label size="sm">({data.length}) {title}</Label>
 			{displayData.map((item, idx) => (
-				createElement(itemComponent, { item, key: idx })
+				createElement(itemComponent, { item, key: getItemKey(item, idx) })
 			))}
 
 			{(data.length > (maxDisplayedItems ?? Infinity)) && (

--- a/packages/ui/src/components/sidebar/SidebarExports/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarExports/index.tsx
@@ -2,6 +2,7 @@
 
 import { type MenuProps } from '@mantine/core';
 import { IconCloudDown, IconCloudMinus } from '@tabler/icons-react';
+import { type FileExport } from '@tmlmobilidade/types';
 
 import { useExportsContext } from '../../../contexts/exports.context';
 import { Menu } from '../../menu/Menu';
@@ -13,6 +14,12 @@ import { SidebarExportsItem } from '../SidebarExportsItem';
 
 export interface SidebarExportsProps {
 	menuPosition?: MenuProps['position']
+}
+
+/* * */
+
+function SidebarExportsMenuItem({ item }: { item: FileExport }) {
+	return <SidebarExportsItem fileExport={item} />;
 }
 
 /* * */
@@ -33,7 +40,7 @@ export function SidebarExports({ menuPosition }: SidebarExportsProps = {}) {
 		<Menu counter={fileExports.length} icon={IconCloudDown} label="Exportações" menuPosition={menuPosition} variant="danger">
 			{fileExports.length === 0
 				? <MenuNoContent icon={IconCloudMinus} text="Sem exportações disponíveis" />
-				: <MenuList data={fileExports} itemComponent={({ item }) => <SidebarExportsItem fileExport={item} />} title="Exportações" />}
+				: <MenuList data={fileExports} getItemKey={item => item._id} itemComponent={SidebarExportsMenuItem} title="Exportações" />}
 		</Menu>
 	);
 

--- a/packages/ui/src/components/sidebar/SidebarNotifications/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarNotifications/index.tsx
@@ -4,6 +4,7 @@
 
 import { type MenuProps } from '@mantine/core';
 import { IconBell, IconBellOff } from '@tabler/icons-react';
+import { type Notification } from '@tmlmobilidade/types';
 
 import { useNotificationsContext } from '../../../contexts/Notifications.context';
 import { Menu } from '../../menu/Menu';
@@ -15,6 +16,12 @@ import { SidebarNotificationsItem } from '../SidebarNotificationsItem';
 
 export interface SidebarNotificationsProps {
 	menuPosition?: MenuProps['position']
+}
+
+/* * */
+
+function SidebarNotificationsMenuItem({ item }: { item: Notification }) {
+	return <SidebarNotificationsItem notification={item} />;
 }
 
 /* * */
@@ -37,8 +44,8 @@ export function SidebarNotifications({ menuPosition }: SidebarNotificationsProps
 	return (
 		<Menu counter={unreadNotifications.length} icon={IconBell} label="Notificações" menuPosition={menuPosition} variant="danger">
 
-			<MenuList data={unreadNotifications} itemComponent={({ item }) => <SidebarNotificationsItem notification={item} />} title="Não Lidas" />
-			<MenuList data={readNotifications} itemComponent={({ item }) => <SidebarNotificationsItem notification={item} />} title="Lidas" />
+			<MenuList data={unreadNotifications} getItemKey={item => item._id} itemComponent={SidebarNotificationsMenuItem} title="Não Lidas" />
+			<MenuList data={readNotifications} getItemKey={item => item._id} itemComponent={SidebarNotificationsMenuItem} title="Lidas" />
 
 			{notifications.length === 0 && (
 				<MenuNoContent icon={IconBellOff} text="Sem notificações disponíveis" />


### PR DESCRIPTION
Use stable item keys in MenuList and pass stable item components for sidebar exports and notifications.

This prevents the dropdown rows from remounting on parent renders, which fixes the hover flicker in the sidebar menus.