### PR TITLE
feat(tracker): ingest TCB GTFS-RT vehicle positions

### DIFF
--- a/modules/tracker/apps/tcb-fetch/eslint.config.mjs
+++ b/modules/tracker/apps/tcb-fetch/eslint.config.mjs
@@ -1,0 +1,9 @@
+/* * */
+
+import { node } from '@tmlmobilidade/eslint'
+
+/* * */
+
+export default [
+  ...node,
+]

--- a/modules/tracker/apps/tcb-fetch/package.json
+++ b/modules/tracker/apps/tcb-fetch/package.json
@@ -23,6 +23,7 @@
 		"@tmlmobilidade/gtfs-rt": "*",
 		"@tmlmobilidade/logger": "*",
 		"@tmlmobilidade/timer": "*",
+		"@tmlmobilidade/types": "*",
 		"@tmlmobilidade/utils": "*"
 	},
 	"devDependencies": {

--- a/modules/tracker/apps/tcb-fetch/package.json
+++ b/modules/tracker/apps/tcb-fetch/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@tmlmobilidade/go-tracker-tcb-fetch",
+	"version": "1.0.0",
+	"author": {
+		"email": "iso@tmlmobilidade.pt",
+		"name": "TML-ISO"
+	},
+	"license": "AGPL-3.0-or-later",
+	"type": "module",
+	"files": ["dist"],
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "tsc && resolve-tspaths",
+		"dev": "tsx watch src/index.ts",
+		"lint": "eslint . --fix && tsc --noEmit",
+		"lint:fix": "eslint . --fix"
+	},
+	"dependencies": {
+		"@tmlmobilidade/databases": "*",
+		"@tmlmobilidade/dates": "*",
+		"@tmlmobilidade/go-tracker-pckg-shared": "*",
+		"@tmlmobilidade/gtfs-rt": "*",
+		"@tmlmobilidade/logger": "*",
+		"@tmlmobilidade/timer": "*",
+		"@tmlmobilidade/utils": "*"
+	},
+	"devDependencies": {
+		"@tmlmobilidade/tsconfig": "*",
+		"@types/node": "25.9.1",
+		"resolve-tspaths": "0.8.23",
+		"tsx": "4.22.3",
+		"typescript": "5.9.3"
+	}
+}

--- a/modules/tracker/apps/tcb-fetch/src/index.ts
+++ b/modules/tracker/apps/tcb-fetch/src/index.ts
@@ -1,0 +1,112 @@
+/* * */
+
+import { rawVehicleEventsNew } from '@tmlmobilidade/databases';
+import { Dates } from '@tmlmobilidade/dates';
+import { decodeGtfsRtFeed } from '@tmlmobilidade/gtfs-rt';
+import { Logger } from '@tmlmobilidade/logger';
+import { Timer } from '@tmlmobilidade/timer';
+import { type HashableRawVehicleEvent, type RawVehicleEventTcbV1 } from '@tmlmobilidade/types';
+import { runOnInterval } from '@tmlmobilidade/utils';
+import crypto from 'node:crypto';
+
+/* * */
+
+const API_URL = 'https://wowsystems.co.uk/gtfs-realtime';
+
+/* * */
+
+let ITERATION = 0;
+
+/* * */
+
+const main = async () => {
+	//
+
+	const timer = new Timer();
+
+	let saveCount = 0;
+
+	//
+	// Fetch the TCB Vehicle Events data from the API and decode it
+
+	Logger.info(`[${ITERATION}] Fetching TCB data from API...`, 0, 1);
+
+	const response = await fetch(API_URL);
+	const arrayBuffer = await response.arrayBuffer();
+	const decodedMessage = await decodeGtfsRtFeed(arrayBuffer);
+
+	Logger.info(`[${ITERATION}] Found ${decodedMessage.entity?.length ?? 0} Vehicle Events in the TCB data.`);
+
+	//
+	// Transform each message into a RawVehicleEvent
+
+	for (const entity of decodedMessage.entity ?? []) {
+		try {
+		//
+
+			//
+			// Skip entities that do not have a vehicle field,
+			// as they are not relevant for our use case.
+
+			if (!entity.vehicle) continue;
+
+			//
+			// Skip entities that do not have a trip field,
+			// as they are not relevant for our use case.
+
+			if (!entity.vehicle.trip) continue;
+
+			//
+			// Hash the relevant fields of the vehicle event
+			// to create a unique identifier for the event.
+			// This allows us to identify duplicate events
+			// and avoid storing them multiple times in the database.
+
+			const hashableRawEvent: HashableRawVehicleEvent<RawVehicleEventTcbV1> = {
+				agency_id: '8',
+				created_at: Dates.fromSeconds(Number(entity.vehicle.timestamp)).unix_timestamp,
+				entity_id: entity.id,
+				payload: {
+					header: decodedMessage.header,
+					vehicle: entity.vehicle,
+				},
+				version: 'tcb-v1',
+			};
+
+			const hashableRawEventId = crypto
+				.createHash('sha256')
+				.update(JSON.stringify(hashableRawEvent))
+				.digest('hex');
+
+			//
+			// Write the new vehicle event document
+			// to the RawVehicleEvents collection
+
+			const alreadyExists = await rawVehicleEventsNew.findOne({ _id: hashableRawEventId });
+
+			if (alreadyExists) continue;
+
+			await rawVehicleEventsNew.insertOne({
+				...hashableRawEvent,
+				_id: hashableRawEventId,
+				received_at: Dates.now('Europe/Lisbon').unix_timestamp,
+			});
+
+			saveCount++;
+
+		//
+		} catch (error) {
+			Logger.error(`[${ITERATION}] Error processing vehicle event entity with ID ${entity.id}:`, error);
+		}
+	}
+
+	Logger.info(`[${ITERATION}] Saved ${saveCount} new Vehicle Events from TCB data in ${timer.get()}.`);
+
+	ITERATION++;
+
+	//
+};
+
+/* * */
+
+await runOnInterval(main, { intervalMs: '1s', throwOnError: true });

--- a/modules/tracker/apps/tcb-fetch/src/index.ts
+++ b/modules/tracker/apps/tcb-fetch/src/index.ts
@@ -5,7 +5,7 @@ import { Dates } from '@tmlmobilidade/dates';
 import { decodeGtfsRtFeed } from '@tmlmobilidade/gtfs-rt';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';
-import { type HashableRawVehicleEvent, type RawVehicleEventTcbV1 } from '@tmlmobilidade/types';
+import { GtfsRtFeedMessage, type HashableRawVehicleEvent, type RawVehicleEventTcbV1 } from '@tmlmobilidade/types';
 import { runOnInterval } from '@tmlmobilidade/utils';
 import crypto from 'node:crypto';
 
@@ -31,30 +31,30 @@ const main = async () => {
 
 	Logger.info(`[${ITERATION}] Fetching TCB data from API...`, 0, 1);
 
-	const response = await fetch(API_URL);
-	const arrayBuffer = await response.arrayBuffer();
-	const decodedMessage = await decodeGtfsRtFeed(arrayBuffer);
+	let decodedMessage: GtfsRtFeedMessage | null = null;
+	try {
+		const response = await fetch(API_URL);
+		const arrayBuffer = await response.arrayBuffer();
+		decodedMessage = await decodeGtfsRtFeed(arrayBuffer);
+	} catch (error) {
+		Logger.error(`[${ITERATION}] Error decoding TCB data:`, error);
+		return;
+	}
 
 	Logger.info(`[${ITERATION}] Found ${decodedMessage.entity?.length ?? 0} Vehicle Events in the TCB data.`);
 
 	//
 	// Transform each message into a RawVehicleEvent
 
+	const candidateEvents: Array<{ _id: string, document: RawVehicleEventTcbV1 }> = [];
+
 	for (const entity of decodedMessage.entity ?? []) {
 		try {
 		//
 
-			//
-			// Skip entities that do not have a vehicle field,
-			// as they are not relevant for our use case.
+			if (!entity.vehicle?.trip) continue;
 
-			if (!entity.vehicle) continue;
-
-			//
-			// Skip entities that do not have a trip field,
-			// as they are not relevant for our use case.
-
-			if (!entity.vehicle.trip) continue;
+			const timestampSeconds = entity.vehicle.timestamp ?? decodedMessage.header.timestamp;
 
 			//
 			// Hash the relevant fields of the vehicle event
@@ -64,7 +64,7 @@ const main = async () => {
 
 			const hashableRawEvent: HashableRawVehicleEvent<RawVehicleEventTcbV1> = {
 				agency_id: '8',
-				created_at: Dates.fromSeconds(Number(entity.vehicle.timestamp)).unix_timestamp,
+				created_at: Dates.fromSeconds(timestampSeconds).unix_timestamp,
 				entity_id: entity.id,
 				payload: {
 					header: decodedMessage.header,
@@ -78,25 +78,41 @@ const main = async () => {
 				.update(JSON.stringify(hashableRawEvent))
 				.digest('hex');
 
-			//
-			// Write the new vehicle event document
-			// to the RawVehicleEvents collection
-
-			const alreadyExists = await rawVehicleEventsNew.findOne({ _id: hashableRawEventId });
-
-			if (alreadyExists) continue;
-
-			await rawVehicleEventsNew.insertOne({
-				...hashableRawEvent,
+			candidateEvents.push({
 				_id: hashableRawEventId,
-				received_at: Dates.now('Europe/Lisbon').unix_timestamp,
+				document: {
+					...hashableRawEvent,
+					_id: hashableRawEventId,
+					received_at: Dates.now('Europe/Lisbon').unix_timestamp,
+				},
 			});
-
-			saveCount++;
 
 		//
 		} catch (error) {
 			Logger.error(`[${ITERATION}] Error processing vehicle event entity with ID ${entity.id}:`, error);
+		}
+	}
+
+	//
+	// Save the new vehicle events to the database
+
+	if (candidateEvents.length > 0) {
+		try {
+			const candidateIds = candidateEvents.map(event => event._id);
+			const existingDocs = await rawVehicleEventsNew.findMany(
+				{ _id: { $in: candidateIds } },
+				{ projection: { _id: 1 } },
+			);
+			const existingIds = new Set(existingDocs.map(doc => doc._id));
+
+			const newEvents = candidateEvents.filter(event => !existingIds.has(event._id));
+
+			if (newEvents.length > 0) {
+				await rawVehicleEventsNew.insertMany(newEvents.map(event => event.document));
+				saveCount = newEvents.length;
+			}
+		} catch (error) {
+			Logger.error(`[${ITERATION}] Error saving vehicle events to database:`, error);
 		}
 	}
 

--- a/modules/tracker/apps/tcb-fetch/src/index.ts
+++ b/modules/tracker/apps/tcb-fetch/src/index.ts
@@ -128,4 +128,4 @@ const main = async () => {
 
 /* * */
 
-await runOnInterval(main, { intervalMs: '1s', throwOnError: true });
+await runOnInterval(main, { intervalMs: '10s', throwOnError: true });

--- a/modules/tracker/apps/tcb-fetch/src/index.ts
+++ b/modules/tracker/apps/tcb-fetch/src/index.ts
@@ -67,7 +67,10 @@ const main = async () => {
 				created_at: Dates.fromSeconds(timestampSeconds).unix_timestamp,
 				entity_id: entity.id,
 				payload: {
-					header: decodedMessage.header,
+					header: {
+						...decodedMessage.header,
+						timestamp: timestampSeconds,
+					},
 					vehicle: entity.vehicle,
 				},
 				version: 'tcb-v1',

--- a/modules/tracker/apps/tcb-fetch/tsconfig.json
+++ b/modules/tracker/apps/tcb-fetch/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "@tmlmobilidade/tsconfig/nodejs.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/modules/tracker/environments/production/compose.yml
+++ b/modules/tracker/environments/production/compose.yml
@@ -198,6 +198,25 @@ services:
   # # # # # # # # # # # # # # # # # # # # #
   # # # # # # # # # # # # # # # # # # # # #
 
+  tcb-fetch:
+    image: ghcr.io/tmlmobilidade/go-tracker-tcb-fetch:production
+    deploy:
+      restart_policy:
+        condition: any
+        delay: 30s
+      resources:
+        limits:
+          memory: 4gb
+    logging:
+      options:
+        max-size: '1m'
+        max-file: '1'
+    env_file:
+      - ./secrets/.env
+
+  # # # # # # # # # # # # # # # # # # # # #
+  # # # # # # # # # # # # # # # # # # # # #
+
   cap-fetch:
     image: ghcr.io/tmlmobilidade/go-tracker-cap-fetch:production
     deploy:

--- a/modules/tracker/environments/staging/compose.yml
+++ b/modules/tracker/environments/staging/compose.yml
@@ -149,6 +149,25 @@ services:
   # # # # # # # # # # # # # # # # # # # # #
   # # # # # # # # # # # # # # # # # # # # #
 
+  tcb-fetch:
+    image: ghcr.io/tmlmobilidade/go-tracker-tcb-fetch:staging
+    deploy:
+      restart_policy:
+        condition: any
+        delay: 30s
+      resources:
+        limits:
+          memory: 4gb
+    logging:
+      options:
+        max-size: '1m'
+        max-file: '1'
+    env_file:
+      - ./secrets/.env
+
+  # # # # # # # # # # # # # # # # # # # # #
+  # # # # # # # # # # # # # # # # # # # # #
+
   cap-fetch:
     image: ghcr.io/tmlmobilidade/go-tracker-cap-fetch:staging
     deploy:

--- a/modules/tracker/packages/parsers/src/index.ts
+++ b/modules/tracker/packages/parsers/src/index.ts
@@ -5,6 +5,7 @@ import { parseRawVehicleEventCmetV1Core } from '@/cmet/cmet-v1-core.js';
 import { parseRawVehicleEventCmetV1Log } from '@/cmet/cmet-v1-log.js';
 import { parseRawVehicleEventCpV1 } from '@/cp/cp-v1.js';
 import { parseRawVehicleEventMobiV1 } from '@/mobi/mobi-v1.js';
+import { parseRawVehicleEventTcbV1 } from '@/tcb/tcb-v1.js';
 import { parseRawVehicleEventTtslV1 } from '@/ttsl/ttsl-v1.js';
 import { type RawVehicleEvent, type SimplifiedVehicleEvent } from '@tmlmobilidade/types';
 
@@ -16,5 +17,6 @@ export const PARSER_MAP: Record<RawVehicleEvent['version'], (vehicleEvent: RawVe
 	'cmet-v1-log': parseRawVehicleEventCmetV1Log,
 	'cp-v1': parseRawVehicleEventCpV1,
 	'mobi-v1': parseRawVehicleEventMobiV1,
+	'tcb-v1': parseRawVehicleEventTcbV1,
 	'ttsl-v1': parseRawVehicleEventTtslV1,
 };

--- a/modules/tracker/packages/parsers/src/tcb/tcb-v1.ts
+++ b/modules/tracker/packages/parsers/src/tcb/tcb-v1.ts
@@ -1,0 +1,36 @@
+/* * */
+
+import { Dates } from '@tmlmobilidade/dates';
+import { clampCoordinate } from '@tmlmobilidade/geo';
+import { type RawVehicleEventTcbV1, type SimplifiedVehicleEvent } from '@tmlmobilidade/types';
+import { roundToInt } from '@tmlmobilidade/utils';
+
+/* * */
+
+export const parseRawVehicleEventTcbV1 = (doc: RawVehicleEventTcbV1): null | SimplifiedVehicleEvent => {
+	const vehicle = doc.payload.vehicle;
+	// Validate coordinates before parsing the rest of the event.
+	const latitude = clampCoordinate(vehicle.position.latitude);
+	const longitude = clampCoordinate(vehicle.position.longitude);
+	if (latitude === null || longitude === null) return null;
+	return {
+		_id: doc._id,
+		agency_id: doc.agency_id,
+		bearing: roundToInt(vehicle.position.bearing),
+		created_at: doc.created_at,
+		current_status: vehicle.current_status ?? null,
+		door: null,
+		driver_id: null,
+		extra_trip_id: null,
+		latitude: latitude,
+		longitude: longitude,
+		odometer: null,
+		operational_date: Dates.fromUnixTimestamp(doc.created_at).operational_date,
+		pattern_id: null,
+		received_at: doc.received_at,
+		speed: roundToInt(vehicle.position.speed),
+		stop_id: vehicle.stop_id || null,
+		trip_id: vehicle.trip.trip_id,
+		vehicle_id: vehicle.vehicle.id,
+	};
+};

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
 		"dev:tracker:mobi-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-mobi-fetch",
 		"dev:tracker:mobi-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-mobi-fetch",
 		"dev:tracker:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-*",
+		"dev:tracker:tcb-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-tcb-fetch",
+		"dev:tracker:tcb-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-tcb-fetch",
 		"dev:tracker:ttsl-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-ttsl-fetch",
 		"dev:tracker:ttsl-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-ttsl-fetch",
 

--- a/packages/types/src/vehicle-events/raw/index.ts
+++ b/packages/types/src/vehicle-events/raw/index.ts
@@ -4,4 +4,5 @@ export * from '@/vehicle-events/raw/cp/index.js';
 export * from '@/vehicle-events/raw/mobi/index.js';
 export * from '@/vehicle-events/raw/raw-vehicle-event-base.js';
 export * from '@/vehicle-events/raw/raw-vehicle-event.js';
+export * from '@/vehicle-events/raw/tcb/index.js';
 export * from '@/vehicle-events/raw/ttsl/index.js';

--- a/packages/types/src/vehicle-events/raw/raw-vehicle-event.ts
+++ b/packages/types/src/vehicle-events/raw/raw-vehicle-event.ts
@@ -5,6 +5,7 @@ import { RawVehicleEventCmetV1CoreSchema } from '@/vehicle-events/raw/cmet/v1-co
 import { RawVehicleEventCmetV1LogSchema } from '@/vehicle-events/raw/cmet/v1-log.js';
 import { RawVehicleEventCpV1Schema } from '@/vehicle-events/raw/cp/v1.js';
 import { RawVehicleEventMobiV1Schema } from '@/vehicle-events/raw/mobi/v1.js';
+import { RawVehicleEventTcbV1Schema } from '@/vehicle-events/raw/tcb/v1.js';
 import { RawVehicleEventTtslV1Schema } from '@/vehicle-events/raw/ttsl/v1.js';
 import { z } from 'zod';
 
@@ -17,6 +18,7 @@ export const RawVehicleEventSchema = z.discriminatedUnion('version', [
 	RawVehicleEventCmetV1LogSchema,
 	RawVehicleEventTtslV1Schema,
 	RawVehicleEventCpV1Schema,
+	RawVehicleEventTcbV1Schema,
 ]);
 
 /**

--- a/packages/types/src/vehicle-events/raw/tcb/index.ts
+++ b/packages/types/src/vehicle-events/raw/tcb/index.ts
@@ -1,0 +1,1 @@
+export * from '@/vehicle-events/raw/tcb/v1.js';

--- a/packages/types/src/vehicle-events/raw/tcb/v1.ts
+++ b/packages/types/src/vehicle-events/raw/tcb/v1.ts
@@ -1,0 +1,51 @@
+/* * */
+
+import { GtfsRtOccupancyStatusSchema } from '@/gtfs-rt/occupancy-status.js';
+import { OperationalDateSchema } from '@/index.js';
+import { RawVehicleEventBaseSchema } from '@/vehicle-events/raw/raw-vehicle-event-base.js';
+import { z } from 'zod';
+
+/* * */
+
+export const RawVehicleEventTcbV1PayloadSchema = z.object({
+	header: z.object({
+		feed_version: z.string().nullish(),
+		gtfs_realtime_version: z.string(),
+		incrementality: z.literal('FULL_DATASET').nullish(),
+		timestamp: z.number(),
+	}),
+	vehicle: z.object({
+		current_status: z.enum(['INCOMING_AT', 'STOPPED_AT', 'IN_TRANSIT_TO']).nullish(),
+		current_stop_sequence: z.number().nullish(),
+		occupancy_status: GtfsRtOccupancyStatusSchema.nullish(),
+		position: z.object({
+			bearing: z.number().nullish(),
+			latitude: z.number(),
+			longitude: z.number(),
+			speed: z.number().nullish(),
+		}),
+		stop_id: z.string().nullish(),
+		timestamp: z.number().nullish(),
+		trip: z.object({
+			direction_id: z.number().nullish(),
+			route_id: z.string(),
+			start_date: OperationalDateSchema.nullish(),
+			start_time: z.string().nullish(),
+			trip_id: z.string(),
+		}),
+		vehicle: z.object({
+			id: z.string(),
+		}),
+	}),
+});
+
+export type RawVehicleEventTcbV1Payload = z.infer<typeof RawVehicleEventTcbV1PayloadSchema>;
+
+/* * */
+
+export const RawVehicleEventTcbV1Schema = RawVehicleEventBaseSchema.extend({
+	payload: RawVehicleEventTcbV1PayloadSchema,
+	version: z.literal('tcb-v1'),
+});
+
+export type RawVehicleEventTcbV1 = z.infer<typeof RawVehicleEventTcbV1Schema>;


### PR DESCRIPTION
## Summary

- Add `tcb-v1` raw vehicle event schema for TCB GTFS-RT payloads (trip, position, stop sequence, vehicle id).
- Add `tcb-fetch` app polling `https://wowsystems.co.uk/gtfs-realtime` every 1s, deduplicating into `rawVehicleEventsNew` (agency `8`).
- Register `parseRawVehicleEventTcbV1` in tracker parsers for clickhouse-stream/sync.
- Deploy `tcb-fetch` in tracker staging and production compose; add `dev:tracker:tcb-fetch` scripts.

## Context

TCB publishes vehicle positions (and trip updates) via wowsystems GTFS-RT. This follows the same pattern as `ccfl-fetch` / `mobi-fetch`: decode protobuf feed, keep only `vehicle` entities with a `trip`, hash for dedup, then simplify downstream.