### PR TITLE
feat(tracker): add Fertagus vehicle events fetch, types, parser, and auth fix

### DIFF
--- a/infra/legacy/sae/scripts/roles.js
+++ b/infra/legacy/sae/scripts/roles.js
@@ -209,6 +209,7 @@ db.updateRole('tracker', {
 		{ actions: ['find'], resource: { collection: 'stops', db: 'production' } },
 		{ actions: ['find'], resource: { collection: 'hashed_shapes', db: 'production' } },
 		{ actions: ['find'], resource: { collection: 'hashed_trips', db: 'production' } },
+		{ actions: ['find'], resource: { collection: 'hashed_patterns', db: 'production' } },
 	],
 	roles: [],
 });

--- a/infra/legacy/sae/scripts/roles.js
+++ b/infra/legacy/sae/scripts/roles.js
@@ -201,6 +201,18 @@ db.createRole({
 	roles: [],
 });
 
+
+db.updateRole('tracker', {
+	privileges: [
+		{ actions: ['find'], resource: { collection: 'rides', db: 'production' } },
+		{ actions: ['find'], resource: { collection: 'plans', db: 'production' } },
+		{ actions: ['find'], resource: { collection: 'stops', db: 'production' } },
+		{ actions: ['find'], resource: { collection: 'hashed_shapes', db: 'production' } },
+		{ actions: ['find'], resource: { collection: 'hashed_trips', db: 'production' } },
+	],
+	roles: [],
+});
+
 db.createRole({
 	privileges: [
 		{ actions: ['find'], resource: { collection: 'rides', db: 'production' } },

--- a/modules/tracker/apps/fertagus-fetch/eslint.config.mjs
+++ b/modules/tracker/apps/fertagus-fetch/eslint.config.mjs
@@ -1,0 +1,9 @@
+/* * */
+
+import { node } from '@tmlmobilidade/eslint'
+
+/* * */
+
+export default [
+  ...node,
+]

--- a/modules/tracker/apps/fertagus-fetch/package.json
+++ b/modules/tracker/apps/fertagus-fetch/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@tmlmobilidade/go-tracker-fertagus-fetch",
+	"version": "1.0.0",
+	"author": {
+		"email": "iso@tmlmobilidade.pt",
+		"name": "TML-ISO"
+	},
+	"license": "AGPL-3.0-or-later",
+	"type": "module",
+	"files": ["dist"],
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "tsc && resolve-tspaths",
+		"dev": "tsx watch src/index.ts",
+		"lint": "eslint . --fix && tsc --noEmit",
+		"lint:fix": "eslint . --fix"
+	},
+	"dependencies": {
+		"@tmlmobilidade/databases": "*",
+		"@tmlmobilidade/dates": "*",
+		"@tmlmobilidade/external": "*",
+		"@tmlmobilidade/go-tracker-pckg-shared": "*",
+		"@tmlmobilidade/gtfs-rt": "*",
+		"@tmlmobilidade/interfaces": "*",
+		"@tmlmobilidade/logger": "*",
+		"@tmlmobilidade/ssh": "*",
+		"@tmlmobilidade/timer": "*",
+		"@tmlmobilidade/types": "*",
+		"@tmlmobilidade/utils": "*"
+	},
+	"devDependencies": {
+		"@tmlmobilidade/tsconfig": "*",
+		"@types/node": "25.9.1",
+		"resolve-tspaths": "0.8.23",
+		"tsx": "4.22.4",
+		"typescript": "5.9.3"
+	}
+}

--- a/modules/tracker/apps/fertagus-fetch/src/index.ts
+++ b/modules/tracker/apps/fertagus-fetch/src/index.ts
@@ -7,13 +7,32 @@ import { TrainsResponse } from '@tmlmobilidade/external/dist/clients/fertagus/ty
 import { rides } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';
-import { type HashableRawVehicleEvent, RawVehicleEventFertagusV1, Ride } from '@tmlmobilidade/types';
+import { type HashableRawVehicleEvent, HashedPattern, RawVehicleEventFertagusV1, Ride } from '@tmlmobilidade/types';
 import { runOnInterval } from '@tmlmobilidade/utils';
 import crypto from 'node:crypto';
 
 /* * */
 
 let ITERATION = 0;
+
+interface FoundRideDocument {
+	_id: Ride['_id']
+	agency_id: Ride['agency_id']
+	first_stop_id: string
+	last_stop_id: string
+	line_id: HashedPattern['line_id']
+	line_long_name: HashedPattern['line_long_name']
+	line_short_name: HashedPattern['line_short_name']
+	pattern_id: HashedPattern['pattern_id']
+	route_color: HashedPattern['route_color']
+	route_id: HashedPattern['route_id']
+	route_long_name: HashedPattern['route_long_name']
+	route_short_name: HashedPattern['route_short_name']
+	route_text_color: HashedPattern['route_text_color']
+	trip_headsign: HashedPattern['trip_headsign']
+	trip_id: Ride['trip_id']
+
+}
 
 /* * */
 
@@ -38,7 +57,7 @@ const main = async () => {
 
 	Logger.info(`[${ITERATION}] Found ${response.length ?? 0} Vehicle Events in the Fertagus data.`);
 
-	const ridesMap = new Map<string, Ride>();
+	const ridesMap = new Map<string, FoundRideDocument>();
 
 	for (const event of response ?? []) {
 		//
@@ -53,7 +72,57 @@ const main = async () => {
 
 		if (!ridesMap.has(rideKey)) {
 			try {
-				const foundRides = await rides.findMany({ agency_id: '15', start_time_scheduled: Dates.fromISO(event.startsAt).unix_timestamp });
+				const ridesCollection = await rides.getCollection();
+				const foundRides = await ridesCollection.aggregate<FoundRideDocument>([
+					{
+						$match: {
+							agency_id: '15',
+							start_time_scheduled: Dates.fromISO(event.startsAt).unix_timestamp,
+						},
+					},
+					{
+						$lookup: {
+							as: 'hashed_pattern',
+							foreignField: '_id',
+							from: 'hashed_patterns',
+							localField: 'hashed_pattern_id',
+						},
+					},
+					{
+						$unwind: '$hashed_pattern',
+					},
+					{
+						$project: {
+							_id: 1,
+							agency_id: 1,
+							first_stop_id: {
+								$first: '$hashed_pattern.path.stop_id',
+							},
+
+							last_stop_id: {
+								$last: '$hashed_pattern.path.stop_id',
+							},
+							line_id: '$hashed_pattern.line_id',
+							line_long_name: '$hashed_pattern.line_long_name',
+							line_short_name: '$hashed_pattern.line_short_name',
+							pattern_id: '$hashed_pattern.pattern_id',
+							route_color: '$hashed_pattern.route_color',
+							route_id: '$hashed_pattern.route_id',
+							route_long_name: '$hashed_pattern.route_long_name',
+							route_short_name: '$hashed_pattern.route_short_name',
+							route_text_color: '$hashed_pattern.route_text_color',
+
+							trip_headsign: '$hashed_pattern.trip_headsign',
+							trip_id: 1,
+						},
+					},
+					{
+						$match: {
+							first_stop_id: event.stop_id_start,
+							last_stop_id: event.stop_id_end,
+						},
+					},
+				]).toArray();
 
 				//
 				// If no ride is found, skip this event.
@@ -65,13 +134,13 @@ const main = async () => {
 				// If multiple rides are found, skip this event.
 				// This can be improved by checking start and end stop IDs.
 				if (foundRides.length > 1) {
-					Logger.error(`[${ITERATION}] Multiple rides found for event ${event.date} ${event.train_id} ${event.stop_id_start} ${event.stop_id_end} ${event.startsAt}.`);
+					Logger.error(`[${ITERATION}] Multiple rides found for event start time scheduled: ${Dates.fromISO(event.startsAt).unix_timestamp} - ${event.stop_id_start} -> ${event.stop_id_end}.`);
 					continue;
 				}
 
 				ridesMap.set(rideKey, foundRides[0]);
 			} catch (error) {
-				Logger.error(`[${ITERATION}] Error finding rides for event ${event.date} ${event.train_id} ${event.stop_id_start} ${event.stop_id_end} ${event.startsAt}:`, error);
+				Logger.error(`[${ITERATION}] Error finding rides for event start time scheduled: ${Dates.fromISO(event.startsAt).unix_timestamp} - ${event.stop_id_start} -> ${event.stop_id_end}:`, error);
 				continue;
 			}
 		}

--- a/modules/tracker/apps/fertagus-fetch/src/index.ts
+++ b/modules/tracker/apps/fertagus-fetch/src/index.ts
@@ -1,0 +1,155 @@
+/* * */
+
+import { rawVehicleEventsNew } from '@tmlmobilidade/databases';
+import { Dates } from '@tmlmobilidade/dates';
+import { externalClients } from '@tmlmobilidade/external';
+import { TrainsResponse } from '@tmlmobilidade/external/dist/clients/fertagus/types.js';
+import { rides } from '@tmlmobilidade/interfaces';
+import { Logger } from '@tmlmobilidade/logger';
+import { Timer } from '@tmlmobilidade/timer';
+import { type HashableRawVehicleEvent, RawVehicleEventFertagusV1, Ride } from '@tmlmobilidade/types';
+import { runOnInterval } from '@tmlmobilidade/utils';
+import crypto from 'node:crypto';
+
+/* * */
+
+let ITERATION = 0;
+
+/* * */
+
+const main = async () => {
+	//
+
+	const timer = new Timer();
+	let saveCount = 0;
+
+	//
+	// Fetch the Fertagus Vehicle Events data from API and decode it.
+
+	Logger.info(`[${ITERATION}] Fetching Fertagus data from API...`, 0, 1);
+
+	let response: null | TrainsResponse = null;
+	try {
+		response = await externalClients.fertagus.trains();
+	} catch (error) {
+		Logger.error(`[${ITERATION}] Error fetching Fertagus data from API:`, error);
+		return;
+	}
+
+	Logger.info(`[${ITERATION}] Found ${response.length ?? 0} Vehicle Events in the Fertagus data.`);
+
+	const ridesMap = new Map<string, Ride>();
+
+	for (const event of response ?? []) {
+		//
+
+		//
+		// Skip events that do not have a date, latitude, longitude, startsAt, stop_id_end, stop_id_start, or train_id.
+		if (!event.date || !event.latitude || !event.longitude || !event.startsAt || !event.stop_id_end || !event.stop_id_start || !event.train_id) continue;
+
+		//
+		// Find the ride of this event.
+		const rideKey = `${event.stop_id_start}-${event.stop_id_end}-${event.startsAt}`;
+
+		if (!ridesMap.has(rideKey)) {
+			try {
+				const foundRides = await rides.findMany({ agency_id: '15', start_time_scheduled: Dates.fromISO(event.startsAt).unix_timestamp });
+
+				//
+				// If no ride is found, skip this event.
+				if (foundRides.length === 0) {
+					Logger.error(`[${ITERATION}] No ride found for event start time scheduled: ${Dates.fromISO(event.startsAt).unix_timestamp} - ${event.stop_id_start} -> ${event.stop_id_end}.`);
+					continue;
+				}
+
+				// If multiple rides are found, skip this event.
+				// This can be improved by checking start and end stop IDs.
+				if (foundRides.length > 1) {
+					Logger.error(`[${ITERATION}] Multiple rides found for event ${event.date} ${event.train_id} ${event.stop_id_start} ${event.stop_id_end} ${event.startsAt}.`);
+					continue;
+				}
+
+				ridesMap.set(rideKey, foundRides[0]);
+			} catch (error) {
+				Logger.error(`[${ITERATION}] Error finding rides for event ${event.date} ${event.train_id} ${event.stop_id_start} ${event.stop_id_end} ${event.startsAt}:`, error);
+				continue;
+			}
+		}
+
+		const eventRide = ridesMap.get(rideKey);
+		if (!eventRide) continue;
+
+		//
+		// Add the ride to the map.
+		ridesMap.set(`${event.stop_id_start}-${event.stop_id_end}-${event.startsAt}`, eventRide);
+
+		//
+		// Hash the relevant fields of the vehicle event
+		// to create a unique identifier for the event.
+		// This allows us to identify duplicate events
+		// and avoid storing them multiple times in the database
+		const hashableRawEvent: HashableRawVehicleEvent<RawVehicleEventFertagusV1> = {
+			agency_id: '15',
+			created_at: Dates.fromISO(event.date).unix_timestamp,
+			entity_id: Buffer.from(`15-${event.date}-${event.train_id}`).toString('base64').replace(/=+$/, ''),
+			payload: {
+				header: {
+					gtfs_realtime_version: '2.0',
+					incrementality: 'FULL_DATASET',
+					timestamp: Dates.fromISO(event.date).unix_timestamp,
+				},
+				vehicle: {
+					agencyId: '15',
+					current_status: 'IN_TRANSIT_TO',
+					position: {
+						latitude: event.latitude,
+						longitude: event.longitude,
+					},
+					timestamp: Dates.fromISO(event.date).unix_timestamp,
+					trip: {
+						line_id: eventRide.line_id.toString(),
+						pattern_id: eventRide.pattern_id,
+						route_id: eventRide.route_id,
+						schedule_relationship: 'SCHEDULED',
+						trip_id: eventRide.trip_id,
+					},
+					vehicle: {
+						id: event.train_id.toString(),
+					},
+				},
+			},
+			version: 'fertagus-v1',
+		};
+
+		const hashableRawEventId = crypto
+			.createHash('sha256')
+			.update(JSON.stringify(hashableRawEvent))
+			.digest('hex');
+
+		//
+		// Write the new vehicle event document
+		// to the RawVehicleEvents collection
+
+		const alreadyExists = await rawVehicleEventsNew.findOne({ _id: hashableRawEventId });
+
+		if (alreadyExists) continue;
+
+		await rawVehicleEventsNew.insertOne({
+			...hashableRawEvent,
+			_id: hashableRawEventId,
+			received_at: Dates.now('Europe/Lisbon').unix_timestamp,
+		});
+
+		saveCount++;
+	}
+
+	Logger.info(`[${ITERATION}] Saved ${saveCount} new Vehicle Events from Fertagus data in ${timer.get()}.`);
+
+	ITERATION++;
+
+	//
+};
+
+/* * */
+
+await runOnInterval(main, { intervalMs: '5s', throwOnError: true });

--- a/modules/tracker/apps/fertagus-fetch/tsconfig.json
+++ b/modules/tracker/apps/fertagus-fetch/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "@tmlmobilidade/tsconfig/nodejs.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/modules/tracker/packages/parsers/src/fertagus/fertagus-v1.ts
+++ b/modules/tracker/packages/parsers/src/fertagus/fertagus-v1.ts
@@ -1,0 +1,35 @@
+/* * */
+
+import { Dates } from '@tmlmobilidade/dates';
+import { clampCoordinate } from '@tmlmobilidade/geo';
+import { type RawVehicleEventFertagusV1, type SimplifiedVehicleEvent } from '@tmlmobilidade/types';
+
+/* * */
+
+export const parseRawVehicleEventFertagusV1 = (doc: RawVehicleEventFertagusV1): null | SimplifiedVehicleEvent => {
+	const vehicle = doc.payload.vehicle;
+	// Validate coordinates before parsing the rest of the event.
+	const latitude = clampCoordinate(vehicle.position.latitude);
+	const longitude = clampCoordinate(vehicle.position.longitude);
+	if (latitude === null || longitude === null) return null;
+	return {
+		_id: doc._id,
+		agency_id: doc.agency_id,
+		bearing: null,
+		created_at: doc.created_at,
+		current_status: vehicle.current_status ?? null,
+		door: null,
+		driver_id: null,
+		extra_trip_id: null,
+		latitude: latitude,
+		longitude: longitude,
+		odometer: null,
+		operational_date: Dates.fromUnixTimestamp(doc.created_at).operational_date,
+		pattern_id: vehicle.trip.pattern_id,
+		received_at: doc.received_at,
+		speed: null,
+		stop_id: null,
+		trip_id: vehicle.trip.trip_id,
+		vehicle_id: vehicle.vehicle.id,
+	};
+};

--- a/modules/tracker/packages/parsers/src/index.ts
+++ b/modules/tracker/packages/parsers/src/index.ts
@@ -5,6 +5,7 @@ import { parseRawVehicleEventCmetV1Core } from '@/cmet/cmet-v1-core.js';
 import { parseRawVehicleEventCmetV1Log } from '@/cmet/cmet-v1-log.js';
 import { parseRawVehicleEventCpV1 } from '@/cp/cp-v1.js';
 import { parseRawVehicleEventCrtmAisaV1 } from '@/crtm-aisa/crtm-aisa-v1.js';
+import { parseRawVehicleEventFertagusV1 } from '@/fertagus/fertagus-v1.js';
 import { parseRawVehicleEventMobiV1 } from '@/mobi/mobi-v1.js';
 import { parseRawVehicleEventTcbV1 } from '@/tcb/tcb-v1.js';
 import { parseRawVehicleEventTtslV1 } from '@/ttsl/ttsl-v1.js';
@@ -18,6 +19,7 @@ export const PARSER_MAP: Record<RawVehicleEvent['version'], (vehicleEvent: RawVe
 	'cmet-v1-log': parseRawVehicleEventCmetV1Log,
 	'cp-v1': parseRawVehicleEventCpV1,
 	'crtm-aisa-v1': parseRawVehicleEventCrtmAisaV1,
+	'fertagus-v1': parseRawVehicleEventFertagusV1,
 	'mobi-v1': parseRawVehicleEventMobiV1,
 	'tcb-v1': parseRawVehicleEventTcbV1,
 	'ttsl-v1': parseRawVehicleEventTtslV1,

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
 		"dev:tracker:cp-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=prd dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-cp-fetch",
 		"dev:tracker:crtm-aisa-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-crtm-aisa-fetch",
 		"dev:tracker:crtm-aisa-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-crtm-aisa-fetch",
+		"dev:tracker:fertagus-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-fertagus-fetch",
+		"dev:tracker:fertagus-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-fertagus-fetch",
 		"dev:tracker:mobi-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-mobi-fetch",
 		"dev:tracker:mobi-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-mobi-fetch",
 		"dev:tracker:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-*",

--- a/packages/external/src/clients/fertagus/auth.ts
+++ b/packages/external/src/clients/fertagus/auth.ts
@@ -72,9 +72,9 @@ export class FertagusAuthClient {
 		// and handle the response, extracting the access token or throwing an error if the request fails.
 
 		const requestBody = new URLSearchParams({
+			client_id: process.env.FERTAGUS_AUTH_USERNAME,
+			client_secret: process.env.FERTAGUS_AUTH_PASSWORD,
 			grant_type: 'client_credentials',
-			password: process.env.FERTAGUS_AUTH_PASSWORD,
-			username: process.env.FERTAGUS_AUTH_USERNAME,
 		}).toString();
 
 		const response = await fetch(process.env.FERTAGUS_AUTH_URL, {

--- a/packages/types/src/vehicle-events/raw/fertagus/index.ts
+++ b/packages/types/src/vehicle-events/raw/fertagus/index.ts
@@ -1,0 +1,1 @@
+export * from '@/vehicle-events/raw/fertagus/v1.js';

--- a/packages/types/src/vehicle-events/raw/fertagus/v1.ts
+++ b/packages/types/src/vehicle-events/raw/fertagus/v1.ts
@@ -1,0 +1,45 @@
+/* * */
+;
+import { UnixTimestampSchema } from '@/index.js';
+import { RawVehicleEventBaseSchema } from '@/vehicle-events/raw/raw-vehicle-event-base.js';
+import { z } from 'zod';
+
+/* * */
+
+export const RawVehicleEventFertagusV1PayloadSchema = z.object({
+	header: z.object({
+		gtfs_realtime_version: z.literal('2.0'),
+		incrementality: z.literal('FULL_DATASET'),
+		timestamp: UnixTimestampSchema,
+	}),
+	vehicle: z.object({
+		agencyId: z.string(),
+		current_status: z.literal('IN_TRANSIT_TO'),
+		position: z.object({
+			latitude: z.number(),
+			longitude: z.number(),
+		}),
+		timestamp: z.number(),
+		trip: z.object({
+			line_id: z.string(),
+			pattern_id: z.string(),
+			route_id: z.string(),
+			schedule_relationship: z.literal('SCHEDULED'),
+			trip_id: z.string(),
+		}),
+		vehicle: z.object({
+			id: z.string(),
+		}),
+	}),
+});
+
+export type RawVehicleEventFertagusV1Payload = z.infer<typeof RawVehicleEventFertagusV1PayloadSchema>;
+
+/* * */
+
+export const RawVehicleEventFertagusV1Schema = RawVehicleEventBaseSchema.extend({
+	payload: RawVehicleEventFertagusV1PayloadSchema,
+	version: z.literal('fertagus-v1'),
+});
+
+export type RawVehicleEventFertagusV1 = z.infer<typeof RawVehicleEventFertagusV1Schema>;

--- a/packages/types/src/vehicle-events/raw/index.ts
+++ b/packages/types/src/vehicle-events/raw/index.ts
@@ -2,6 +2,7 @@ export * from '@/vehicle-events/raw/ccfl/index.js';
 export * from '@/vehicle-events/raw/cmet/index.js';
 export * from '@/vehicle-events/raw/cp/index.js';
 export * from '@/vehicle-events/raw/crtm-aisa/index.js';
+export * from '@/vehicle-events/raw/fertagus/index.js';
 export * from '@/vehicle-events/raw/mobi/index.js';
 export * from '@/vehicle-events/raw/raw-vehicle-event-base.js';
 export * from '@/vehicle-events/raw/raw-vehicle-event.js';

--- a/packages/types/src/vehicle-events/raw/raw-vehicle-event.ts
+++ b/packages/types/src/vehicle-events/raw/raw-vehicle-event.ts
@@ -5,6 +5,7 @@ import { RawVehicleEventCmetV1CoreSchema } from '@/vehicle-events/raw/cmet/v1-co
 import { RawVehicleEventCmetV1LogSchema } from '@/vehicle-events/raw/cmet/v1-log.js';
 import { RawVehicleEventCpV1Schema } from '@/vehicle-events/raw/cp/v1.js';
 import { RawVehicleEventCrtmAisaV1Schema } from '@/vehicle-events/raw/crtm-aisa/v1.js';
+import { RawVehicleEventFertagusV1Schema } from '@/vehicle-events/raw/fertagus/v1.js';
 import { RawVehicleEventMobiV1Schema } from '@/vehicle-events/raw/mobi/v1.js';
 import { RawVehicleEventTcbV1Schema } from '@/vehicle-events/raw/tcb/v1.js';
 import { RawVehicleEventTtslV1Schema } from '@/vehicle-events/raw/ttsl/v1.js';
@@ -21,6 +22,7 @@ export const RawVehicleEventSchema = z.discriminatedUnion('version', [
 	RawVehicleEventCpV1Schema,
 	RawVehicleEventCrtmAisaV1Schema,
 	RawVehicleEventTcbV1Schema,
+	RawVehicleEventFertagusV1Schema,
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Adds real-time vehicle event fetching for **Fertagus** (train operator), completing the tracker's coverage of Fertagus alongside existing CP, CCFL, TTSL, Mobi, and CRTM-Aisa providers.

## Changes

### New: Fertagus fetch app
- **`modules/tracker/apps/fertagus-fetch/`** — Polls the Fertagus API every 5 seconds, matches events to scheduled rides via `rides` + `hashed_patterns` collections, deduplicates by SHA-256 hash, and writes new `RawVehicleEventFertagusV1` documents to MongoDB.
- Includes package config, ESLint, and tsconfig.

### New: Fertagus raw vehicle event type
- **`packages/types/src/vehicle-events/raw/fertagus/v1.ts`** — Zod schema and TypeScript type for the `fertagus-v1` event version, following the existing conventions.

### New: Fertagus event parser
- **`modules/tracker/packages/parsers/src/fertagus/fertagus-v1.ts`** — Parses raw Fertagus events into `SimplifiedVehicleEvent`, with coordinate clamping and field mapping.
- Registered in `PARSER_MAP` as `'fertagus-v1'`.

### Fix: Fertagus OAuth2 authentication
- **`packages/external/src/clients/fertagus/auth.ts`** — Changed request body from `username`/`password` to `client_id`/`client_secret` to match the OAuth2 `client_credentials` grant spec.

### Other
- **`infra/legacy/sae/scripts/roles.js`** — Granted `tracker` role `find` access on `rides`, `plans`, `stops`, `hashed_shapes`, `hashed_trips`, and `hashed_patterns`.
- **`package.json`** — Added `dev:tracker:fertagus-fetch` and `dev:tracker:fertagus-fetch:prd` scripts.
