### PR TITLE
fix(exporter): handle missing ride export filters

### DIFF
--- a/modules/exporter/apps/export-files/src/index.ts
+++ b/modules/exporter/apps/export-files/src/index.ts
@@ -30,8 +30,10 @@ async function main() {
 		let pathToFile: string | undefined;
 
 		try {
-		//
-		// Process the file export.
+			Logger.info(`Processing file export ${fileExport._id} (${fileExport.type}).`);
+
+			//
+			// Process the file export.
 			switch (fileExport.type) {
 				case 'ride':
 					pathToFile = await exportRidesFile(fileExport);
@@ -72,7 +74,7 @@ async function main() {
 			}
 		} catch (error) {
 			Logger.error(error);
-			Logger.error(`Error processing file export: ${error instanceof Error ? error.message : 'Unknown error'}.`);
+			Logger.error(`Error processing file export ${fileExport._id} (${fileExport.type}): ${error instanceof Error ? error.message : 'Unknown error'}.`);
 			await fileExports.updateById(fileExport._id, { processing_status: 'error' });
 			continue;
 		}

--- a/modules/exporter/apps/export-files/src/lib/parse-ride.ts
+++ b/modules/exporter/apps/export-files/src/lib/parse-ride.ts
@@ -15,14 +15,14 @@ export function parseRide(ride: RideNormalized & { acceptance: null | RideAccept
 		/* * */
 		_id: ride._id,
 		agency_id: ride.agency_id,
-		driver_ids: ride.driver_ids.join('|'),
+		driver_ids: ride.driver_ids?.join('|') ?? null,
 		headsign: ride.headsign,
 		line_id: ride.line_id,
 		pattern_id: ride.pattern_id,
 		plan_id: ride.plan_id,
 		route_id: ride.route_id,
 		trip_id: ride.trip_id,
-		vehicle_ids: ride.vehicle_ids.join('|'),
+		vehicle_ids: ride.vehicle_ids?.join('|') ?? null,
 
 		/* TIME & STATUS */
 		/* * */
@@ -69,7 +69,7 @@ export function parseRide(ride: RideNormalized & { acceptance: null | RideAccept
 		analysis_EXPECTED_APEX_VALIDATION_INTERVAL: ride.analysis?.EXPECTED_APEX_VALIDATION_INTERVAL?.grade ?? null,
 		analysis_EXPECTED_DRIVER_ID_QTY: ride.analysis?.EXPECTED_DRIVER_ID_QTY?.grade ?? null,
 		analysis_EXPECTED_START_TIME: ride.analysis?.EXPECTED_START_TIME?.grade ?? null,
-		analysis_EXPECTED_START_TIME_value: ride.analysis?.EXPECTED_START_TIME.value ?? null,
+		analysis_EXPECTED_START_TIME_value: ride.analysis?.EXPECTED_START_TIME?.value ?? null,
 		analysis_EXPECTED_VEHICLE_EVENT_DELAY: ride.analysis?.EXPECTED_VEHICLE_EVENT_DELAY?.grade ?? null,
 		analysis_EXPECTED_VEHICLE_EVENT_INTERVAL: ride.analysis?.EXPECTED_VEHICLE_EVENT_INTERVAL?.grade ?? null,
 		analysis_EXPECTED_VEHICLE_EVENT_QTY: ride.analysis?.EXPECTED_VEHICLE_EVENT_QTY?.grade ?? null,

--- a/packages/interfaces/src/interfaces/rides/pipelines.ts
+++ b/packages/interfaces/src/interfaces/rides/pipelines.ts
@@ -281,13 +281,13 @@ export function ridesPipelineSeenStatus({ filter }: { filter?: { seen_status?: S
 
 export function ridesPipelineTicketingStatus({ filter }: { filter?: { ticketing_status?: TicketingStatus[] } } = {}): AggregationPipeline<Ride> {
 	const pipeline: AggregationPipeline<Ride> = [];
-	if (filter?.ticketing_status?.length) return pipeline;
+	if (!filter?.ticketing_status?.length) return pipeline;
 
 	const includesHasTicketing = filter.ticketing_status.includes('has_ticketing');
 	const includesNoTicketing = filter.ticketing_status.includes('no_ticketing');
 
 	// If both are present, match all documents (no filter needed)
-	if (includesHasTicketing && !includesNoTicketing) return pipeline;
+	if (includesHasTicketing && includesNoTicketing) return pipeline;
 
 	if (includesHasTicketing) {
 		pipeline.push({ $match: { apex_validations_qty: { $gte: 1 } } });


### PR DESCRIPTION
Guard optional ride export fields before parsing and fix the ticketing status pipeline so absent filters do not crash export generation.