### PR TITLE
feat/Add CRTM La Veloz (GRUPO SAMAR) GTFS client and vehicle positions

### DIFF
--- a/modules/tracker/apps/crtm-laveloz-fetch/eslint.config.mjs
+++ b/modules/tracker/apps/crtm-laveloz-fetch/eslint.config.mjs
@@ -1,0 +1,9 @@
+/* * */
+
+import { node } from '@tmlmobilidade/eslint'
+
+/* * */
+
+export default [
+  ...node,
+]

--- a/modules/tracker/apps/crtm-laveloz-fetch/package.json
+++ b/modules/tracker/apps/crtm-laveloz-fetch/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@tmlmobilidade/go-tracker-crtm-laveloz-fetch",
+	"version": "1.0.0",
+	"author": {
+		"email": "iso@tmlmobilidade.pt",
+		"name": "TML-ISO"
+	},
+	"license": "AGPL-3.0-or-later",
+	"type": "module",
+	"files": ["dist"],
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "tsc && resolve-tspaths",
+		"dev": "tsx watch src/index.ts",
+		"lint": "eslint . --fix && tsc --noEmit",
+		"lint:fix": "eslint . --fix"
+	},
+	"dependencies": {
+		"@tmlmobilidade/databases": "*",
+		"@tmlmobilidade/dates": "*",
+		"@tmlmobilidade/external": "*",
+		"@tmlmobilidade/gtfs-rt": "*",
+		"@tmlmobilidade/logger": "*",
+		"@tmlmobilidade/timer": "*",
+		"@tmlmobilidade/utils": "*"
+	},
+	"devDependencies": {
+		"@tmlmobilidade/tsconfig": "*",
+		"@types/node": "26.0.0",
+		"resolve-tspaths": "0.8.23",
+		"tsx": "4.22.4",
+		"typescript": "6.0.3"
+	}
+}

--- a/modules/tracker/apps/crtm-laveloz-fetch/src/index.ts
+++ b/modules/tracker/apps/crtm-laveloz-fetch/src/index.ts
@@ -1,0 +1,115 @@
+/* * */
+
+import { rawVehicleEventsNew } from '@tmlmobilidade/databases';
+import { Dates } from '@tmlmobilidade/dates';
+import { externalClients } from '@tmlmobilidade/external';
+import { Logger } from '@tmlmobilidade/logger';
+import { initSentryNode } from '@tmlmobilidade/logger';
+import { Timer } from '@tmlmobilidade/timer';
+import { type HashableRawVehicleEvent, type RawVehicleEventCrtmLaVelozV1 } from '@tmlmobilidade/types';
+import { runOnInterval } from '@tmlmobilidade/utils';
+import crypto from 'node:crypto';
+
+/* * */
+
+let ITERATION = 0;
+
+/* * */
+
+const main = async () => {
+	//
+
+	// Initialize Sentry
+
+	try {
+		await initSentryNode();
+		Logger.startNodeLogs({ app: 'crtm-laveloz-fetch', message: 'Sentry Tracker CRTM La Veloz Fetch initialized', module: 'tracker', severity: 'info' });
+	} catch (error) {
+		Logger.error({ error, message: 'Error initializing Sentry Tracker CRTM La Veloz Fetch' });
+	}
+
+	//
+	// Initialize the timer
+
+	const timer = new Timer();
+
+	let saveCount = 0;
+
+	//
+	// Fetch the CRTM La Veloz Vehicle Events data from the API and decode it
+
+	Logger.info({ message: `[${ITERATION}] Fetching CRTM La Veloz data from API...`, spacesAfterOrBefore: 1, spacesBefore: 0 });
+
+	const decodedMessage = await externalClients.crtmLaVeloz.vehiclePositions();
+
+	Logger.info({ message: `[${ITERATION}] Found ${decodedMessage.entity?.length ?? 0} Vehicle Events in the CRTM La Veloz data.` });
+
+	//
+	// Transform each message into a RawVehicleEvent
+
+	for (const entity of decodedMessage.entity ?? []) {
+		try {
+		//
+
+			//
+			// Skip entities that do not have a vehicle field,
+			// as they are not relevant for our use case.
+
+			if (!entity.vehicle) continue;
+
+			if (!entity.vehicle?.trip?.trip_id) continue;
+
+			//
+			// Hash the relevant fields of the vehicle event
+			// to create a unique identifier for the event.
+			// This allows us to identify duplicate events
+			// and avoid storing them multiple times in the database.
+
+			const hashableRawEvent: HashableRawVehicleEvent<RawVehicleEventCrtmLaVelozV1> = {
+				agency_id: 'crtm-laveloz',
+				created_at: Dates.fromSeconds(Number(entity.vehicle.timestamp)).unix_timestamp,
+				entity_id: entity.id,
+				payload: {
+					header: decodedMessage.header,
+					vehicle: entity.vehicle,
+				},
+				version: 'crtm-laveloz-v1',
+			};
+
+			const hashableRawEventId = crypto
+				.createHash('sha256')
+				.update(JSON.stringify(hashableRawEvent))
+				.digest('hex');
+
+			//
+			// Write the new vehicle event document
+			// to the RawVehicleEvents collection
+
+			const alreadyExists = await rawVehicleEventsNew.findOne({ _id: hashableRawEventId });
+
+			if (alreadyExists) continue;
+
+			await rawVehicleEventsNew.insertOne({
+				...hashableRawEvent,
+				_id: hashableRawEventId,
+				received_at: Dates.now('Europe/Lisbon').unix_timestamp,
+			});
+
+			saveCount++;
+
+		//
+		} catch (error) {
+			Logger.error({ error, message: `[${ITERATION}] Error processing vehicle event entity with ID ${entity.id}:` });
+		}
+	}
+
+	Logger.info({ message: `[${ITERATION}] Saved ${saveCount} new Vehicle Events from CRTM La Veloz data in ${timer.get()}.` });
+
+	ITERATION++;
+
+	//
+};
+
+/* * */
+
+await runOnInterval(main, { intervalMs: '5s', throwOnError: false });

--- a/modules/tracker/apps/crtm-laveloz-fetch/tsconfig.json
+++ b/modules/tracker/apps/crtm-laveloz-fetch/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "@tmlmobilidade/tsconfig/nodejs.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
 		"dev:tracker:cp-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=prd dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-cp-fetch",
 		"dev:tracker:crtm-aisa-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-crtm-aisa-fetch",
 		"dev:tracker:crtm-aisa-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-crtm-aisa-fetch",
+		"dev:tracker:crtm-laveloz-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-crtm-laveloz-fetch",
+		"dev:tracker:crtm-laveloz-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-crtm-laveloz-fetch",
 		"dev:tracker:fertagus-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-fertagus-fetch",
 		"dev:tracker:fertagus-fetch:prd": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/production/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-fertagus-fetch",
 		"dev:tracker:ml-fetch": "npm run build:tracker:packages && ENVIRONMENT=dev dotenv-run -f ./modules/tracker/environments/staging/secrets/.env -- turbo run dev --filter=@tmlmobilidade/go-tracker-ml-fetch",

--- a/packages/external/src/clients/crtm-laveloz/index.ts
+++ b/packages/external/src/clients/crtm-laveloz/index.ts
@@ -1,0 +1,73 @@
+/* * */
+
+import { decodeGtfsRtFeed } from '@tmlmobilidade/gtfs-rt';
+import { type GtfsRtFeedMessage } from '@tmlmobilidade/types';
+
+/* * */
+
+const BASE_URL = process.env.CRTM_LAVELOZ_API_URL;
+
+async function fetcher(endpoint: string): Promise<Response> {
+	if (!BASE_URL) {
+		throw new Error('Missing CRTM_LAVELOZ_API_URL environment variable.');
+	}
+
+	const response = await fetch(
+		`${BASE_URL}${endpoint}`,
+		{
+			headers: {
+				Accept: 'application/json, text/plain',
+				Authorization: process.env.CRTM_LAVELOZ_API_KEY,
+			},
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(`Request failed (${response.status}): ${response.statusText}`);
+	}
+
+	return response;
+}
+
+const endpoints = {
+	serviceAlerts: '/gtfs-rt-alerts/v2',
+	tripUpdates: '/gtfs-rt-trip-updates',
+	vehiclePositions: '/gtfs-rt-vehicle-positions',
+};
+
+export const CrtmLaVelozClient = Object.freeze({
+	//
+
+	/**
+	 * Fetches GTFS-RT Vehicle Positions feed from the CRTM La Veloz API.
+	 *
+	 * @returns {Promise<GtfsRtFeedMessage>} A promise that resolves with the decoded GTFS-RT Vehicle Positions feed message.
+	 */
+	vehiclePositions: async (): Promise<GtfsRtFeedMessage> => {
+		const response = await fetcher(endpoints.vehiclePositions);
+		const arrayBuffer = await response.arrayBuffer();
+		return decodeGtfsRtFeed(arrayBuffer);
+	},
+
+	/**
+	 * Fetches GTFS-RT Trip Updates feed from the CRTM La Veloz API.
+	 *
+	 * @returns {Promise<GtfsRtFeedMessage>} A promise that resolves with the decoded GTFS-RT Trip Updates feed message.
+	 */
+	tripUpdates: async (): Promise<GtfsRtFeedMessage> => {
+		const response = await fetcher(endpoints.tripUpdates);
+		const arrayBuffer = await response.arrayBuffer();
+		return decodeGtfsRtFeed(arrayBuffer);
+	},
+
+	/**
+	 * Fetches GTFS-RT Service Alerts feed from the CRTM La Veloz API.
+	 *
+	 * @returns {Promise<GtfsRtFeedMessage>} A promise that resolves with the decoded GTFS-RT Service Alerts feed message.
+	 */
+	serviceAlerts: async (): Promise<GtfsRtFeedMessage> => {
+		const response = await fetcher(endpoints.serviceAlerts);
+		const arrayBuffer = await response.arrayBuffer();
+		return decodeGtfsRtFeed(arrayBuffer);
+	},
+}) satisfies Record<keyof typeof endpoints, () => Promise<unknown>>;

--- a/packages/external/src/index.ts
+++ b/packages/external/src/index.ts
@@ -3,6 +3,7 @@
 import { CcflClient } from './clients/ccfl/index.js';
 import { CpClient } from './clients/cp/index.js';
 import { CrtmAisaClient } from './clients/crtm-aisa/index.js';
+import { CrtmLaVelozClient } from './clients/crtm-laveloz/index.js';
 import { FertagusClient } from './clients/fertagus/index.js';
 import { MlClient } from './clients/ml/index.js';
 import { MobiClient } from './clients/mobi/index.js';
@@ -19,6 +20,7 @@ import { TtslClient } from './clients/ttsl/index.js';
  * - ccfl: Companhia dos Caminhos de Ferro de Lisboa (CCFL) AKA Carris Munícipal API Client.
  * - cp: Comboios de Portugal (CP) API Client
  * - crtmAisa: Consorcio Regional de Transportes de Madrid (AISACRTM) API Client
+ * - crtmLaVeloz: Consorcio Regional de Transportes de La Veloz (CRTM La Veloz) API Client
  * - mobi: MobiCascais API Client
  * - ml: Metro Lisboa (ML) API Client
  * - tcb: Transportes Colectivos do Barreiro (TCB) API Client
@@ -28,6 +30,7 @@ export const externalClients = Object.freeze({
 	ccfl: CcflClient,
 	cp: CpClient,
 	crtmAisa: CrtmAisaClient,
+	crtmLaVeloz: CrtmLaVelozClient,
 	fertagus: FertagusClient,
 	ml: MlClient,
 	mobi: MobiClient,

--- a/packages/types/src/vehicle-events/raw/crtm-laveloz/index.ts
+++ b/packages/types/src/vehicle-events/raw/crtm-laveloz/index.ts
@@ -1,0 +1,1 @@
+export * from '@/vehicle-events/raw/crtm-laveloz/v1.js';

--- a/packages/types/src/vehicle-events/raw/crtm-laveloz/v1.ts
+++ b/packages/types/src/vehicle-events/raw/crtm-laveloz/v1.ts
@@ -1,0 +1,46 @@
+/* * */
+
+import {
+	GtfsRtOccupancyStatusSchema,
+	GtfsRtPositionSchema,
+	GtfsRtVehicleDescriptorSchema,
+	GtfsRtVehicleStopStatusSchema,
+} from '@/gtfs-rt/index.js';
+import { RawVehicleEventBaseSchema } from '@/vehicle-events/raw/raw-vehicle-event-base.js';
+import { z } from 'zod';
+
+/* * */
+
+export const RawVehicleEventCrtmLaVelozV1PayloadSchema = z.object({
+	header: z.object({
+		feed_version: z.string().nullish(),
+		gtfs_realtime_version: z.string(),
+		incrementality: z.literal('FULL_DATASET'),
+		timestamp: z.number(),
+	}),
+	vehicle: z.object({
+		current_status: GtfsRtVehicleStopStatusSchema.nullish(),
+		occupancy_status: GtfsRtOccupancyStatusSchema.nullish(),
+		position: GtfsRtPositionSchema,
+		stop_id: z.string().nullish(),
+		timestamp: z.number().nullish(),
+		trip: z.object({
+			route_id: z.string().nullish(),
+			schedule_relationship: z.enum(['SCHEDULED', 'ADDED', 'UNSCHEDULED', 'CANCELED']).nullish(),
+			start_date: z.string().nullish(),
+			trip_id: z.string(),
+		}),
+		vehicle: GtfsRtVehicleDescriptorSchema,
+	}),
+});
+
+export type RawVehicleEventCrtmLaVelozV1Payload = z.infer<typeof RawVehicleEventCrtmLaVelozV1PayloadSchema>;
+
+/* * */
+
+export const RawVehicleEventCrtmLaVelozV1Schema = RawVehicleEventBaseSchema.extend({
+	payload: RawVehicleEventCrtmLaVelozV1PayloadSchema,
+	version: z.literal('crtm-laveloz-v1'),
+});
+
+export type RawVehicleEventCrtmLaVelozV1 = z.infer<typeof RawVehicleEventCrtmLaVelozV1Schema>;

--- a/packages/types/src/vehicle-events/raw/index.ts
+++ b/packages/types/src/vehicle-events/raw/index.ts
@@ -2,6 +2,7 @@ export * from '@/vehicle-events/raw/ccfl/index.js';
 export * from '@/vehicle-events/raw/cmet/index.js';
 export * from '@/vehicle-events/raw/cp/index.js';
 export * from '@/vehicle-events/raw/crtm-aisa/index.js';
+export * from '@/vehicle-events/raw/crtm-laveloz/index.js';
 export * from '@/vehicle-events/raw/fertagus/index.js';
 export * from '@/vehicle-events/raw/ml/index.js';
 export * from '@/vehicle-events/raw/mobi/index.js';

--- a/packages/types/src/vehicle-events/raw/raw-vehicle-event.ts
+++ b/packages/types/src/vehicle-events/raw/raw-vehicle-event.ts
@@ -5,6 +5,7 @@ import { RawVehicleEventCmetV1CoreSchema } from '@/vehicle-events/raw/cmet/v1-co
 import { RawVehicleEventCmetV1LogSchema } from '@/vehicle-events/raw/cmet/v1-log.js';
 import { RawVehicleEventCpV1Schema } from '@/vehicle-events/raw/cp/v1.js';
 import { RawVehicleEventCrtmAisaV1Schema } from '@/vehicle-events/raw/crtm-aisa/v1.js';
+import { RawVehicleEventCrtmLaVelozV1Schema } from '@/vehicle-events/raw/crtm-laveloz/v1.js';
 import { RawVehicleEventFertagusV1Schema } from '@/vehicle-events/raw/fertagus/v1.js';
 import { RawVehicleEventMlV1Schema } from '@/vehicle-events/raw/ml/v1.js';
 import { RawVehicleEventMobiV1Schema } from '@/vehicle-events/raw/mobi/v1.js';
@@ -23,6 +24,7 @@ export const RawVehicleEventSchema = z.discriminatedUnion('version', [
 	RawVehicleEventTtslV1Schema,
 	RawVehicleEventCpV1Schema,
 	RawVehicleEventCrtmAisaV1Schema,
+	RawVehicleEventCrtmLaVelozV1Schema,
 	RawVehicleEventTcbV1Schema,
 	RawVehicleEventFertagusV1Schema,
 ]);


### PR DESCRIPTION
## Summary

Add support for La Veloz (GRUPO SAMAR), a Spanish bus operator whose GTFS data is exposed via goswift.ly. Includes an external API client, vehicle event schema, and a tracker fetch app to poll and persist vehicle positions.

## Changes

### External client (`packages/external/`)
- **New** `clients/crtm-laveloz/index.ts` — API client wrapping goswift.ly real-time feeds (Vehicle Positions, Trip Updates, Service Alerts) with Bearer token auth via `Authorization` header
- **Updated** `index.ts` — register `CrtmLaVelozClient` in `externalClients` barrel export

### Types (`packages/types/`)
- **New** `vehicle-events/raw/crtm-laveloz/v1.ts` — `RawVehicleEventCrtmLaVelozV1` schema reusing shared GTFS-RT schemas (`GtfsRtPositionSchema`, `GtfsRtVehicleDescriptorSchema`, etc.)
- **New** `vehicle-events/raw/crtm-laveloz/index.ts` — barrel export
- **Updated** `vehicle-events/raw/index.ts` — re-export new module
- **Updated** `vehicle-events/raw/raw-vehicle-event.ts` — register in `RawVehicleEventSchema` discriminated union

### Tracker fetch app (`modules/tracker/`)
- **New** `apps/crtm-laveloz-fetch/` — fetch app that polls vehicle positions every 5s, hashes entities, and upserts deduplicated raw events to MongoDB

### Root
- **Updated** `package.json` — add `dev:tracker:crtm-laveloz-fetch` and `dev:tracker:crtm-laveloz-fetch:prd` scripts

## API details

| Feed | URL | Auth |
|---|---|---|
| Static GTFS | `https://laveloz.es/gtfs/gtfs.zip` | None |
| Vehicle Positions | `https://api.goswift.ly/real-time/es-samar-crtm/gtfs-rt-vehicle-positions` | `Authorization: Bearer {key}` |
| Trip Updates | `https://api.goswift.ly/real-time/es-samar-crtm/gtfs-rt-trip-updates` | `Authorization: Bearer {key}` |
| Service Alerts | `https://api.goswift.ly/real-time/es-samar-crtm/gtfs-rt-alerts/v2` | `Authorization: Bearer {key}` |

## Environment variables

| Variable | Purpose |
|---|---|
| `CRTM_LAVELOZ_API_URL` | Base URL (`https://api.goswift.ly/real-time/es-samar-crtm`) |
| `CRTM_LAVELOZ_API_KEY` | Bearer token provided by GRUPO SAMAR |

## Commits

- `c943b9c31` — feat(crtm-laveloz): add CRTM La Veloz API client
- `6d857c44f` — feat(crtm-laveloz): add CRTM La Veloz event schema and payload
- `2b2a53fbc` — feat(crtm-laveloz): add CRTM La Veloz fetch functionality