### PR TITLE
fix(ml-fetch): add logging and validation for skipped trains

### DIFF
--- a/modules/tracker/apps/ml-fetch/src/group-train-positions.ts
+++ b/modules/tracker/apps/ml-fetch/src/group-train-positions.ts
@@ -1,6 +1,7 @@
 /* * */
 
 import { DESTINATION_MAP, type TempoEsperaRawItem } from '@tmlmobilidade/external/dist/clients/ml/types.js';
+import { Logger } from '@tmlmobilidade/logger';
 
 import { type TrainPositionsMap } from './types.js';
 
@@ -11,17 +12,29 @@ export function groupTrainPositions({ items, trainPositionsMap }: { items: Tempo
 	for (const item of items) {
 		if (!item.comboio || item.tempoChegada1 === '--') continue;
 
-		const trainId = item.comboio;
-		const destinationId = DESTINATION_MAP[item.destino as unknown as keyof typeof DESTINATION_MAP]?.code;
-		const arrivalSeconds = Number.parseInt(item.tempoChegada1);
-		const stopId = item.stop_id;
-
-		if (!trainPositionsMap.has(trainId)) {
-			trainPositionsMap.set(trainId, { destination_id: destinationId, next_stop: { arrival_seconds: arrivalSeconds, stop_id: stopId } });
+		const destinationCode = DESTINATION_MAP[item.destino as unknown as keyof typeof DESTINATION_MAP]?.code;
+		if (!destinationCode) {
+			Logger.debug({ message: `[groupTrainPositions] Unknown destino "${item.destino}" for train ${item.comboio} (stop_id: ${item.stop_id}), skipping` });
+			continue;
 		}
 
-		if (arrivalSeconds < trainPositionsMap.get(trainId)!.next_stop.arrival_seconds) {
-			trainPositionsMap.get(trainId)!.next_stop = { arrival_seconds: arrivalSeconds, stop_id: stopId };
+		const arrivalSeconds = Number.parseInt(item.tempoChegada1);
+		if (Number.isNaN(arrivalSeconds)) {
+			Logger.debug({ message: `[groupTrainPositions] Invalid arrival for train ${item.comboio}: "${item.tempoChegada1}"` });
+			continue;
+		}
+
+		const existing = trainPositionsMap.get(item.comboio);
+		if (!existing) {
+			trainPositionsMap.set(item.comboio, {
+				destination_id: destinationCode,
+				next_stop: { arrival_seconds: arrivalSeconds, stop_id: item.stop_id },
+			});
+		} else if (arrivalSeconds < existing.next_stop.arrival_seconds) {
+			trainPositionsMap.set(item.comboio, {
+				destination_id: destinationCode,
+				next_stop: { arrival_seconds: arrivalSeconds, stop_id: item.stop_id },
+			});
 		}
 	}
 }

--- a/modules/tracker/apps/ml-fetch/src/group-train-positions.ts
+++ b/modules/tracker/apps/ml-fetch/src/group-train-positions.ts
@@ -25,12 +25,7 @@ export function groupTrainPositions({ items, trainPositionsMap }: { items: Tempo
 		}
 
 		const existing = trainPositionsMap.get(item.comboio);
-		if (!existing) {
-			trainPositionsMap.set(item.comboio, {
-				destination_id: destinationCode,
-				next_stop: { arrival_seconds: arrivalSeconds, stop_id: item.stop_id },
-			});
-		} else if (arrivalSeconds < existing.next_stop.arrival_seconds) {
+		if (!existing || arrivalSeconds < existing.next_stop.arrival_seconds) {
 			trainPositionsMap.set(item.comboio, {
 				destination_id: destinationCode,
 				next_stop: { arrival_seconds: arrivalSeconds, stop_id: item.stop_id },

--- a/modules/tracker/apps/ml-fetch/src/index.ts
+++ b/modules/tracker/apps/ml-fetch/src/index.ts
@@ -37,15 +37,8 @@ const main = async () => {
 	//
 	// Initialize the timer
 
-	const now = Dates.now('Europe/Lisbon');
 	const timer = new Timer();
 	let saveCount = 0;
-
-	//
-	// Initialize the train positions map.
-	// This groups the upcoming trains per line so we can infer where each one is.
-
-	const trainPositionsMap: TrainPositionsMap = new Map();
 
 	//
 	// Fetch the Metro Lisboa Vehicle Events data from API and decode it.
@@ -57,24 +50,36 @@ const main = async () => {
 	for (const line of lines) {
 		//
 
-		//
-		// Reset the per-line train grouping map.
+		// Use a fresh timestamp per line so the ride time window stays accurate.
 
-		trainPositionsMap.clear();
+		const now = Dates.now('Europe/Lisbon');
+
+		//
+		// Initialize a per-line train grouping map.
+
+		const trainPositionsMap: TrainPositionsMap = new Map();
 
 		//
 		// Fetch the waiting times for this line.
 		// On error, log and continue to the next line.
 
 		let response: BaseResponse<TempoEsperaRawItem[]> | null = null;
+		let apiOk = true;
 		try {
 			response = await externalClients.ml.tempoEsperaLinha(line);
 		} catch (error) {
 			Logger.error({ error, message: `[${ITERATION}] Error fetching Metro Lisboa data from API for line ${line}:` });
+			apiOk = false;
+		}
+
+		if (!apiOk) {
+			Logger.info({ message: `[${ITERATION}] API call failed for line ${line}, no data to process.` });
 			continue;
 		}
 
-		groupTrainPositions({ items: response.resposta, trainPositionsMap });
+		groupTrainPositions({ items: response!.resposta, trainPositionsMap });
+
+		Logger.info({ message: `[${ITERATION}] Line ${line}: ${trainPositionsMap.size} unique trains found in API response.` });
 
 		//
 		// For each train, infer its current position.
@@ -95,7 +100,10 @@ const main = async () => {
 				continue;
 			}
 
-			if (!ride) continue;
+			if (!ride) {
+				Logger.info({ message: `[${ITERATION}] No ride found for train ${trainId} on line ${line} (destinationId: ${destinationId}), skipping.` });
+				continue;
+			}
 
 			// Given the next stop (from the API) and the matched ride document, extract the waypoints in the ride's shape that correspond to:
 			// - nextStopWaypoint: The shape point nearest to the nextStop.
@@ -103,7 +111,10 @@ const main = async () => {
 
 			const { nextStopWaypoint, previousStopWaypoint } = findTripStopWaypoints({ nextStop, ride });
 
-			if (!nextStopWaypoint) continue;
+			if (!nextStopWaypoint) {
+				Logger.info({ message: `[${ITERATION}] No waypoint found for stop ${nextStop.stop_id} on ride ${ride.trip_id} for train ${trainId} on line ${line}, skipping.` });
+				continue;
+			}
 
 			// Infer the train's current position as a point [longitude, latitude] on the ride's shape,
 			// using the next stop, corresponding waypoints, and ride details.


### PR DESCRIPTION
## Problema

O ml-fetch não encontra consistentemente todos os comboios em circulação (valores oscilam entre 0 e 18 em vez dos ~20 esperados).

## Causas identificadas

1. **Destinos não mapeados**: comboios com \destino\ sem correspondência no \DESTINATION_MAP\ são adicionados ao map com \destination_id: undefined\ e depois silenciosamente descartados em \indRideForTrain\
2. **NaN silencioso**: \Number.parseInt\ em dados inválidos não era validado
3. **Timestamp fixo**: \
ow\ era calculado uma vez no início, mas as 4 linhas são processadas sequencialmente — a janela temporal podia desviar-se para as últimas linhas
4. **Sem visibilidade**: não havia logging nos pontos de dropout para diagnosticar o problema

## Alterações

### \group-train-positions.ts\
- Se o \destinationCode\ não existe no mapa, o item é saltado com \Logger.debug\
- Validação de \Number.isNaN\ no \rrivalSeconds\ antes de usar
- Quando é encontrada uma chegada mais cedo para o mesmo comboio, \destination_id\ e \
ext_stop\ são actualizados em conjunto

### \index.ts\
- \
ow\ agora é calculado por linha em vez de uma vez no início do ciclo
- \	rainPositionsMap\ é local a cada linha (em vez de partilhado com \clear()\)
- Logging em cada ponto de dropout: API falhou, ride não encontrada com \destinationId\ visível, waypoint não encontrado
- Contagem de comboios únicos por linha após grouping