### PR TITLE
Update trip-updates endpoints for GTFS format

### DIFF
--- a/modules/hub/apps/api/src/endpoints/v1/realtime/routes.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/realtime/routes.ts
@@ -26,7 +26,8 @@ server.register(
 		instance.get('/vehicles/positions/gtfs.pb', getVehiclePositionsGtfsRtProtobuf);
 
 		instance.get('/trip-updates', getTripUpdatesGtfsRtJson);
-		instance.get('/trip-updates.pb', getTripUpdatesGtfsRtProtobuf);
+		instance.get('/trip-updates/gtfs', getTripUpdatesGtfsRtJson);
+		instance.get('/trip-updates/gtfs.pb', getTripUpdatesGtfsRtProtobuf);
 
 		next();
 	},

--- a/packages/consts/src/app-routes.ts
+++ b/packages/consts/src/app-routes.ts
@@ -359,7 +359,8 @@ export const API_ROUTES = Object.freeze({
 
 		// REALTIME
 		REALTIME_TRIP_UPDATES: `${getModuleConfig('hub', 'api_url')}/v1/realtime/trip-updates`,
-		REALTIME_TRIP_UPDATES_PB: `${getModuleConfig('hub', 'api_url')}/v1/realtime/trip-updates.pb`,
+		REALTIME_TRIP_UPDATES_GTFS: `${getModuleConfig('hub', 'api_url')}/v1/realtime/trip-updates/gtfs`,
+		REALTIME_TRIP_UPDATES_GTFS_PB: `${getModuleConfig('hub', 'api_url')}/v1/realtime/trip-updates/gtfs.pb`,
 		REALTIME_VEHICLES_METADATA: `${getModuleConfig('hub', 'api_url')}/v1/realtime/vehicles/metadata`,
 		REALTIME_VEHICLES_POSITIONS: `${getModuleConfig('hub', 'api_url')}/v1/realtime/vehicles/positions`,
 		REALTIME_VEHICLES_POSITIONS_GTFS: `${getModuleConfig('hub', 'api_url')}/v1/realtime/vehicles/positions/gtfs`,


### PR DESCRIPTION
- Added new endpoints for trip updates in GTFS JSON and Protobuf formats.
- Updated API routes to reflect the new structure, enhancing clarity and consistency in accessing trip updates.