### PR TITLE
feat/add-spanish-translafeat(i18n): add Spanish translations across all modulestions

### DIFF
--- a/modules/alerts/apps/frontend/src/app/layout.tsx
+++ b/modules/alerts/apps/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 /* * */
 
 import pjson from '#/package.json';
-import { i18nResourceKeysPt } from '@/i18n/resources';
+import { i18nResourceKeysEs, i18nResourceKeysPt } from '@/i18n/resources';
 import { DataProviders } from '@/providers/data-providers';
 import { AppProvider, AppWrapper, BaseProvider } from '@tmlmobilidade/ui';
 import { type Metadata } from 'next';
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: PropsWithChildren) {
 	return (
-		<BaseProvider i18n={{ pt: i18nResourceKeysPt }} version={pjson.version}>
+		<BaseProvider i18n={{ es: i18nResourceKeysEs, pt: i18nResourceKeysPt }} version={pjson.version}>
 			<AppProvider>
 				<DataProviders>
 					<AppWrapper>

--- a/modules/alerts/apps/frontend/src/i18n/namespaces/default/es.json
+++ b/modules/alerts/apps/frontend/src/i18n/namespaces/default/es.json
@@ -1,0 +1,40 @@
+{
+	"alerts": {
+		"create": {
+			"causes": {
+				"no_data": "No hay causas disponibles"
+			},
+			"effects": {
+				"no_data": "No hay efectos disponibles"
+			},
+			"references": {
+				"no_data": "No hay tipos de referencia disponibles"
+			},
+			"summary": {
+				"auto_texts": {
+					"label": "Textos automáticos"
+				},
+				"coordinates": {
+					"label": "Coordenadas geográficas"
+				},
+				"description": {
+					"label": "Descripción"
+				},
+				"generate_text": {
+					"label": "Generar texto automático"
+				},
+				"info_url": {
+					"description": "Opcionalmente incluya la URL de un sitio web donde se pueda obtener más información",
+					"label": "Enlace adicional"
+				},
+				"title": {
+					"label": "Título"
+				},
+				"user_instructions": {
+					"label": "Información adicional para la generación del texto automático (opcional)",
+					"placeholder": "Ej.: Desvío por la calle X, sentido Y, debido a Z."
+				}
+			}
+		}
+	}
+}

--- a/modules/alerts/apps/frontend/src/i18n/resources.ts
+++ b/modules/alerts/apps/frontend/src/i18n/resources.ts
@@ -1,7 +1,8 @@
 'use client';
 
+import namespaceDefaultEs from '@/i18n/namespaces/default/es.json' with { type: 'json' };
 import namespaceDefaultPt from '@/i18n/namespaces/default/pt.json' with { type: 'json' };
-import { i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
+import { i18nResourceKeysEsShared, i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
 
 /**
  * Resource keys for i18n translations in Portuguese.
@@ -13,4 +14,12 @@ import { i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
 export const i18nResourceKeysPt = {
 	...i18nResourceKeysPtShared,
 	default: namespaceDefaultPt,
+} as const;
+
+/**
+ * Resource keys for i18n translations in Spanish.
+ */
+export const i18nResourceKeysEs = {
+	...i18nResourceKeysEsShared,
+	default: namespaceDefaultEs,
 } as const;

--- a/modules/auth/apps/frontend/src/app/layout.tsx
+++ b/modules/auth/apps/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 /* * */
 
 import pjson from '#/package.json';
-import { i18nResourceKeysPt } from '@/i18n/resources';
+import { i18nResourceKeysEs, i18nResourceKeysPt } from '@/i18n/resources';
 import { BaseProvider } from '@tmlmobilidade/ui';
 import { Metadata } from 'next';
 import { type PropsWithChildren } from 'react';
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: PropsWithChildren) {
 	return (
-		<BaseProvider i18n={{ pt: i18nResourceKeysPt }} version={pjson.version}>
+		<BaseProvider i18n={{ es: i18nResourceKeysEs, pt: i18nResourceKeysPt }} version={pjson.version}>
 			{children}
 		</BaseProvider>
 	);

--- a/modules/auth/apps/frontend/src/i18n/namespaces/default/es.json
+++ b/modules/auth/apps/frontend/src/i18n/namespaces/default/es.json
@@ -1,0 +1,775 @@
+{
+	"agencies": {
+		"NoDataLabel": {
+			"text": "Seleccione una agencia"
+		},
+		"detail": {
+			"SectionAlertsMap": {
+				"description": "Mapeo de causas, efectos y tipos de referencia para alertas de servicio.",
+				"table": {
+					"header": {
+						"effect": "Efecto"
+					}
+				},
+				"title": "Alertas"
+			},
+			"SectionBasicInfo": {
+				"description": "Nombre, email, teléfono, URL y zona horaria.",
+				"fields": {
+					"code": {
+						"label": "Código",
+						"placeholder": "44"
+					},
+					"fare_url": {
+						"label": "URL para información de tarifas",
+						"placeholder": "https://www.carrismetropolitana.pt/tarifas"
+					},
+					"name": {
+						"label": "Nombre del operador",
+						"placeholder": "Alsa Todi"
+					},
+					"phone": {
+						"label": "Contacto telefónico",
+						"placeholder": "912345678"
+					},
+					"public_email": {
+						"label": "Email público",
+						"placeholder": "email@example.com"
+					},
+					"public_name": {
+						"label": "Nombre público",
+						"placeholder": "Carris Metropolitana"
+					},
+					"short_name": {
+						"label": "Nombre corto",
+						"placeholder": "CM"
+					},
+					"timezone": {
+						"label": "Zona horaria"
+					},
+					"website_url": {
+						"label": "Sitio web",
+						"placeholder": "https://www.carrismetropolitana.pt"
+					}
+				},
+				"title": "Detalles del operador"
+			},
+			"SectionContacts": {
+				"description": "Notificaciones y contactos",
+				"fields": {
+					"contact_emails_pta": {
+						"description": "Las notificaciones se enviarán a los emails de contacto de la autoridad.",
+						"label": "Emails de contacto de la autoridad"
+					},
+					"contact_emails_pto": {
+						"description": "Las notificaciones se enviarán a los siguientes emails de contacto del operador.",
+						"label": "Emails de contacto del operador"
+					}
+				},
+				"title": "Contactos"
+			},
+			"SectionFinancials": {
+				"description": "Información financiera",
+				"fields": {
+					"price_per_km": {
+						"label": "Precio por km",
+						"placeholder": "1.50"
+					},
+					"total_vkm_per_year": {
+						"label": "Total de km por año",
+						"placeholder": "1000000"
+					}
+				},
+				"title": "Información financiera de la agencia"
+			},
+			"SectionValidationRules": {
+				"description": "Archivo de reglas de validación del GTFS",
+				"fields": {
+					"file": {
+						"button": "Cargar reglas",
+						"label": "Insertar reglas de validación del GTFS"
+					},
+					"file_content": {
+						"button": "Descargar reglas",
+						"label": "Descargar reglas de validación del GTFS",
+						"no_content": "No hay reglas de validación definidas"
+					}
+				},
+				"title": "Reglas de validación del GTFS",
+				"toasts": {
+					"error": {
+						"message": "No fue posible leer el archivo JSON. Verifique el contenido.",
+						"title": "Error al procesar el archivo."
+					},
+					"file_type": {
+						"message": "El archivo enviado excede el límite permitido.",
+						"title": "Tipo de archivo inválido."
+					},
+					"max_size": {
+						"message": "El archivo enviado excede el límite permitido.",
+						"title": "Archivo demasiado grande."
+					},
+					"read_only": {
+						"message": "El documento está en modo de visualización.",
+						"title": "No es posible actualizar las reglas de validación."
+					},
+					"success": {
+						"message": "El archivo enviado fue aceptado. Guarde los cambios para activar.",
+						"title": "Reglas cargadas."
+					}
+				}
+			},
+			"header": {
+				"save": "Guardar"
+			}
+		},
+		"list": {
+			"Header": {
+				"title": "Operadores"
+			},
+			"Table": {
+				"columns": {
+					"code": "Código",
+					"id": "#ID",
+					"name": "Nombre"
+				}
+			}
+		}
+	},
+	"common": {
+		"FileComponent": {
+			"downloadError": "Error al descargar el archivo",
+			"downloadFailed": "No fue posible generar el archivo JSON.",
+			"downloadStarted": "Descarga iniciada correctamente.",
+			"downloadTitle": "Descargando archivo"
+		},
+		"IconChooser": {
+			"label": "Iconos"
+		},
+		"UploadImage": {
+			"DeleteButton": {
+				"confirm": {
+					"message": "¿Está seguro de que desea eliminar la imagen?",
+					"title": "Eliminar imagen"
+				}
+			},
+			"Error": {
+				"message": "El tamaño del archivo excede el límite permitido",
+				"title": "Error al cargar la imagen"
+			},
+			"FileButton": {
+				"label": "Cargar imagen"
+			}
+		}
+	},
+	"home": {
+		"Wiki": {
+			"list": {
+				"columns": {
+					"category": {
+						"label": "Categorías"
+					},
+					"title": {
+						"label": "Título"
+					}
+				}
+			}
+		}
+	},
+	"organizations": {
+		"NoDataLabel": {
+			"text": "Seleccione una organización"
+		},
+		"create": {
+			"Header": {
+				"PublishButton": {
+					"label": "Publicar"
+				},
+				"title": "Crear organización"
+			},
+			"SectionBasicInfo": {
+				"fields": {
+					"long_name": {
+						"label": "Nombre de la organización",
+						"placeholder": "Carris Metropolitana"
+					},
+					"short_name": {
+						"label": "Sigla",
+						"placeholder": "CM"
+					}
+				}
+			}
+		},
+		"detail": {
+			"Header": {
+				"DeleteButton": {
+					"Confirm": {
+						"message": "¿Está seguro de que desea eliminar esta organización? Esta acción es irreversible.",
+						"title": "Eliminar organización"
+					},
+					"NewOrganizationButton": {
+						"label": "Nueva organización"
+					}
+				}
+			},
+			"QuickLinks": {
+				"AddQuickLinkButton": {
+					"label": "Añadir enlace rápido"
+				},
+				"NoOrganizationLabel": {
+					"label": "Cree primero la organización para añadir enlaces rápidos."
+				},
+				"description": "Enlaces rápidos que aparecen en la página de inicio.",
+				"table": {
+					"columns": {
+						"actions": {
+							"label": "Acciones"
+						},
+						"icon": {
+							"label": "Icono"
+						},
+						"link": {
+							"label": "Enlace"
+						},
+						"name": {
+							"label": "Nombre"
+						}
+					}
+				},
+				"title": "Enlaces rápidos"
+			},
+			"QuickLinksModal": {
+				"Error": {
+					"message": "Por favor, rellene todos los campos",
+					"title": "Por favor, introduzca una URL válida"
+				},
+				"Fields": {
+					"cancel": {
+						"label": "Cancelar"
+					},
+					"link": {
+						"label": "Enlace"
+					},
+					"save": {
+						"label": "Guardar"
+					},
+					"title": {
+						"label": "Nombre"
+					}
+				}
+			},
+			"SectionBasicInfo": {
+				"description": "Detalles como nombre, sigla, logotipo, enlaces de la página de inicio.",
+				"fields": {
+					"logo_dark": {
+						"label": "Logotipo en modo oscuro"
+					},
+					"logo_light": {
+						"label": "Logotipo en modo claro"
+					},
+					"long_name": {
+						"label": "Nombre de la organización",
+						"placeholder": "Carris Metropolitana"
+					},
+					"short_name": {
+						"label": "Sigla",
+						"placeholder": "CM"
+					}
+				},
+				"title": "Información general"
+			}
+		},
+		"list": {
+			"header": {
+				"NewOrganizationButton": {
+					"label": "Nueva organización"
+				},
+				"title": "Organizaciones"
+			},
+			"table": {
+				"columns": {
+					"id": {
+						"label": "#ID"
+					},
+					"name": {
+						"label": "Nombre"
+					}
+				}
+			}
+		}
+	},
+	"permissions": {
+		"AgencyPermissionMultiselect": {
+			"all": "Todas las agencias",
+			"description": "Operadores a los que el usuario tiene acceso para esta acción.",
+			"label": "Operadores"
+
+		},
+		"AlertReferenceTypePermissionMultiselect": {
+			"alertReferenceTypeOptionsWithAllowAll": {
+				"all": "Tipos de referencia",
+				"lines": "Líneas",
+				"rides": "Circulaciones",
+				"stops": "Paradas"
+			},
+			"all": "Todo tipo de referencias",
+			"description": "Seleccione los tipos de referencia que este usuario podrá utilizar.",
+			"label": "Tipos de referencia"
+		},
+		"SectionItems": {
+			"label": "Permiso heredado del grupo de permisos"
+		},
+		"agencyActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de operadores.",
+			"descriptions": {
+				"create": "Permite crear un operador",
+				"delete": "Permite eliminar un operador",
+				"read": "Permite ver operadores",
+				"toggleLock": "Permite bloquear/desbloquear un operador",
+				"update": "Permite editar un operador"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"toggleLock": "Bloquear/desbloquear",
+				"update": "Editar"
+			},
+			"title": "Permisos de operadores"
+		},
+		"alertActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de alertas.",
+			"descriptions": {
+				"create": "Permite crear una alerta",
+				"delete": "Permite eliminar una alerta",
+				"read": "Permite ver alertas",
+				"toggleLock": "Permite bloquear/desbloquear una alerta",
+				"update": "Permite editar una alerta"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"toggleLock": "Bloquear/desbloquear",
+				"update": "Editar"
+			},
+			"title": "Permisos de alertas"
+		},
+		"annotationsActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de anotaciones.",
+			"title": "Permisos de anotaciones"
+		},
+		"datesActions": {
+			"descriptions": {
+				"createAnnotations": "Permite crear una anotación",
+				"deleteAnnotations": "Permite eliminar una anotación",
+				"readAnnotations": "Permite ver anotaciones",
+				"toggleLockAnnotations": "Permite bloquear/desbloquear una anotación",
+				"updateAnnotations": "Permite editar una anotación"
+			},
+			"labels": {
+				"createAnnotations": "Crear anotación",
+				"deleteAnnotations": "Eliminar anotación",
+				"readAnnotations": "Ver anotaciones",
+				"toggleLockAnnotations": "Bloquear/desbloquear",
+				"updateAnnotations": "Editar anotación"
+			}
+		},
+		"gtfsValidationActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de validaciones GTFS.",
+			"descriptions": {
+				"create": "Permite crear una validación",
+				"read": "Permite ver validaciones",
+				"requestApproval": "Permite solicitar la aprobación de una validación"
+			},
+			"labels": {
+				"create": "Crear",
+				"read": "Ver",
+				"requestApproval": "Solicitar aprobación"
+			},
+			"title": "Permisos de validaciones (GTFS)"
+		},
+		"homeActions": {
+			"description": "Las acciones que el usuario puede realizar en la página de inicio.",
+			"descriptions": {
+				"seeQuickLinks": "Permite ver enlaces rápidos",
+				"seeWikiLinks": "Permite ver la wiki"
+			},
+			"labels": {
+				"seeQuickLinks": "Ver enlaces rápidos",
+				"seeWikiLinks": "Ver wiki"
+			},
+			"title": "Permisos de la página de inicio"
+		},
+		"organizationActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de organizaciones.",
+			"descriptions": {
+				"create": "Permite crear una organización",
+				"delete": "Permite eliminar una organización",
+				"read": "Permite ver organizaciones",
+				"toggleLock": "Permite bloquear/desbloquear una organización",
+				"update": "Permite editar una organización"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"toggleLock": "Bloquear/desbloquear",
+				"update": "Editar"
+			},
+			"title": "Permisos de organizaciones"
+		},
+		"performanceActions": {
+			"description": "Las acciones que el usuario puede realizar en la visualización de métricas.",
+			"descriptions": {
+				"read": "Permite ver métricas"
+			},
+			"labels": {
+				"read": "Ver"
+			},
+			"title": "Permisos de métricas"
+		},
+		"periodsActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de períodos.",
+			"descriptions": {
+				"create": "Permite crear un período",
+				"delete": "Permite eliminar un período",
+				"read": "Permite ver períodos",
+				"toggleLock": "Permite bloquear/desbloquear un período",
+				"update": "Permite editar un período"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"toggleLock": "Bloquear/desbloquear",
+				"update": "Editar"
+			},
+			"title": "Permisos de períodos"
+		},
+		"planActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de planes.",
+			"descriptions": {
+				"create": "Permite crear un plan",
+				"delete": "Permite eliminar un plan",
+				"read": "Permite ver un plan específico",
+				"readController": "Permite ver la configuración de los SLAs de un plan",
+				"readPcgiLegacy": "Permite ver los datos de PCGI Legacy",
+				"toggleLock": "Permite bloquear/desbloquear un plan",
+				"update": "Permite editar un plan",
+				"updateController": "Permite configurar los SLAs de un plan",
+				"updateFeedInfoDates": "Permite editar las fechas de información del feed",
+				"updateGtfsPlan": "Permite cambiar el GTFS de un plan",
+				"updatePcgiLegacy": "Permite editar los datos de PCGI Legacy"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"readController": "Ver SLA Controller",
+				"readPcgiLegacy": "Ver PCGI Legacy",
+				"toggleLock": "Bloquear/Desbloquear",
+				"update": "Editar",
+				"updateController": "Editar SLA Controller",
+				"updateFeedInfoDates": "Editar fechas de validez",
+				"updateGtfsPlan": "Cambiar GTFS",
+				"updatePcgiLegacy": "Editar PCGI Legacy"
+			},
+			"title": "Permisos de planes"
+		},
+		"realtimeActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de alertas en tiempo real.",
+			"descriptions": {
+				"create": "Permite crear una alerta en tiempo real",
+				"delete": "Permite eliminar una alerta en tiempo real",
+				"read": "Permite ver alertas en tiempo real",
+				"toggleLock": "Permite bloquear/desbloquear una alerta en tiempo real",
+				"update": "Permite editar una alerta en tiempo real"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"toggleLock": "Bloquear/desbloquear",
+				"update": "Editar"
+			},
+			"title": "Permisos de alertas en tiempo real"
+		},
+		"rideActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de viajes.",
+			"descriptions": {
+				"acceptanceChangeStatus": "Permite cambiar el estado de una justificación de un viaje",
+				"acceptanceJustify": "Permite justificar un viaje",
+				"acceptanceLock": "Permite bloquear/desbloquear una justificación de un viaje",
+				"acceptanceRead": "Permite ver una justificación de un viaje",
+				"analsysLock": "Permite bloquear/desbloquear un análisis de un viaje",
+				"analysisRead": "Permite ver un análisis de un viaje",
+				"analysisReprocess": "Permite reprocesar un análisis de un viaje",
+				"analysisUpdate": "Permite editar un análisis de un viaje",
+				"auditLock": "Permite bloquear/desbloquear una auditoría de un viaje",
+				"auditRead": "Permite ver una auditoría de un viaje",
+				"auditUpdate": "Permite editar una auditoría de un viaje"
+			},
+			"labels": {
+				"acceptanceChangeStatus": "Aceptación - Cambiar estado",
+				"acceptanceJustify": "Aceptación - Justificar",
+				"acceptanceLock": "Aceptación - Bloquear/Desbloquear",
+				"acceptanceRead": "Aceptación - Ver",
+				"analsysLock": "Análisis - Bloquear/Desbloquear",
+				"analysisRead": "Análisis - Ver",
+				"analysisReprocess": "Análisis - Reprocesar",
+				"analysisUpdate": "Análisis - Editar",
+				"auditLock": "Auditoría - Bloquear/Desbloquear",
+				"auditRead": "Auditoría - Ver",
+				"auditUpdate": "Auditoría - Editar"
+			},
+			"title": "Permisos de viajes"
+		},
+		"roleActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de grupos de permisos.",
+			"descriptions": {
+				"create": "Permite crear un grupo de permisos",
+				"delete": "Permite eliminar un grupo de permisos",
+				"read": "Permite ver grupos de permisos",
+				"toggleLock": "Permite bloquear/desbloquear un grupo de permisos",
+				"update": "Permite editar un grupo de permisos"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"toggleLock": "Bloquear/desbloquear",
+				"update": "Editar"
+			},
+			"title": "Permisos de grupos de permisos"
+		},
+		"stopActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de paradas.",
+			"descriptions": {
+				"create": "Permite crear una parada",
+				"delete": "Permite eliminar una parada",
+				"read": "Permite ver paradas",
+				"toggleLock": "Permite bloquear/desbloquear una parada",
+				"update": "Permite editar una parada"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"toggleLock": "Bloquear/Desbloquear",
+				"update": "Editar"
+			},
+			"title": "Permisos de paradas"
+		},
+		"userActions": {
+			"description": "Las acciones que el usuario puede realizar en la gestión de usuarios.",
+			"descriptions": {
+				"create": "Permite crear un usuario",
+				"delete": "Permite eliminar un usuario",
+				"read": "Permite ver usuarios",
+				"toggleLock": "Permite bloquear/desbloquear un usuario",
+				"update": "Permite editar un usuario"
+			},
+			"labels": {
+				"create": "Crear",
+				"delete": "Eliminar",
+				"read": "Ver",
+				"toggleLock": "Bloquear/desbloquear",
+				"update": "Editar"
+			},
+			"title": "Permisos de usuarios"
+		}
+	},
+	"roles": {
+		"create": {
+			"BasicInfo": {
+				"fields": {
+					"name": {
+						"label": "Nombre del grupo",
+						"placeholder": "..."
+					}
+				}
+			},
+			"Header": {
+				"NewRoleButton": {
+					"label": "Nuevo grupo de permisos"
+				},
+				"SaveButton": {
+					"label": "Crear"
+				}
+			}
+		},
+		"detail": {
+			"BasicInfo": {
+				"description": "Información básica del usuario",
+				"fields": {
+					"name": {
+						"label": "Nombre del grupo",
+						"placeholder": "..."
+					}
+				},
+				"title": "Información básica"
+			},
+			"header": {
+				"DeleteButton": {
+					"confirm": {
+						"message": "¿Está seguro de que desea eliminar este grupo de permisos? Esta acción es irreversible.",
+						"title": "Eliminar grupo de permisos"
+					}
+				},
+				"NewRoleButton": {
+					"label": "Nuevo grupo de permisos"
+				}
+			}
+		},
+		"list": {
+			"Header": {
+				"NewRoleButton": {
+					"label": "Nuevo grupo de permisos"
+				},
+				"Table": {
+					"columns": {
+						"id": "#ID",
+						"name": "Nombre",
+						"permissions": "Permisos"
+					}
+				},
+				"title": "Grupos de permisos"
+			}
+		}
+	},
+	"users": {
+		"create": {
+			"BasicInfo": {
+				"fields": {
+					"email": {
+						"label": "Email",
+						"placeholder": "user@example.com"
+					},
+					"first_name": {
+						"label": "Nombre",
+						"placeholder": "..."
+					},
+					"last_name": {
+						"label": "Apellido",
+						"placeholder": "..."
+					}
+				}
+			},
+			"Header": {
+				"NewUserButton": {
+					"label": "Nuevo usuario"
+				},
+				"SaveButton": {
+					"label": "Crear"
+				}
+			},
+			"OrganizationAndRoles": {
+				"fields": {
+					"organization": {
+						"label": "Organización",
+						"placeholder": "Seleccione una opción..."
+					},
+					"roles": {
+						"label": "Roles",
+						"placeholder": "Seleccione una opción..."
+					}
+				}
+			}
+		},
+		"detail": {
+			"BasicInfo": {
+				"description": "Información básica del usuario",
+				"fields": {
+					"email": {
+						"label": "Email",
+						"placeholder": "user@example.com"
+					},
+					"first_name": {
+						"label": "Nombre",
+						"placeholder": "..."
+					},
+					"last_name": {
+						"label": "Apellido",
+						"placeholder": "..."
+					},
+					"password": {
+						"label": "Contraseña",
+						"placeholder": "..."
+					},
+					"phone": {
+						"label": "Teléfono móvil",
+						"placeholder": "912345678"
+					}
+				},
+				"title": "Información básica"
+			},
+			"Header": {
+				"DeleteButton": {
+					"confirm": {
+						"message": "¿Está seguro de que desea eliminar este usuario? Esta acción es irreversible.",
+						"title": "Eliminar usuario"
+					}
+				},
+				"NewUserButton": {
+					"label": "Nuevo usuario"
+				}
+			},
+			"RolesAndOrganization": {
+				"description": "El conjunto de permisos que el usuario tiene asignado en el sistema y las organizaciones a las que pertenece.",
+				"fields": {
+					"organization": {
+						"label": "Organización",
+						"placeholder": "Seleccione una opción..."
+					},
+					"roles": {
+						"label": "Roles",
+						"placeholder": "Seleccione una opción..."
+					}
+				},
+				"title": "Roles y organizaciones"
+			}
+		},
+		"list": {
+			"FilterBar": {
+				"organization": {
+					"label": "Organización"
+				},
+				"role": {
+					"label": "Grupos"
+				}
+			},
+			"Header": {
+				"NewUserButton": {
+					"label": "Nuevo usuario"
+				},
+				"title": "Usuarios"
+			},
+			"Idle": {
+				"text": "Seleccione un usuario"
+			},
+			"Table": {
+				"columns": {
+					"email": {
+						"label": "Email"
+					},
+					"id": {
+						"label": "#ID"
+					},
+					"lastSeenAt": {
+						"label": "Última visita"
+					},
+					"name": {
+						"label": "Nombre"
+					},
+					"organizationId": {
+						"label": "Organización"
+					},
+					"roleIds": {
+						"label": "Grupos"
+					}
+				}
+			}
+		}
+	}
+}

--- a/modules/auth/apps/frontend/src/i18n/namespaces/unauthenticated/es.json
+++ b/modules/auth/apps/frontend/src/i18n/namespaces/unauthenticated/es.json
@@ -1,0 +1,77 @@
+{
+	"ChangePasswordForm": {
+		"description": "Introduzca su nueva contraseña",
+		"error_message": {
+			"description": "Se produjo un error al intentar cambiar la contraseña",
+			"title": "Error al intentar cambiar la contraseña"
+		},
+		"fields": {
+			"confirm_password": {
+				"placeholder": "Confirmar contraseña"
+			},
+			"password": {
+				"placeholder": "Contraseña"
+			}
+		},
+		"footer": {
+			"label": "Volver al inicio de sesión"
+		},
+		"submit": {
+			"label": "Confirmar"
+		},
+		"success": {
+			"description": "Contraseña cambiada correctamente.",
+			"title": "Éxito"
+		},
+		"title": "Cambiar contraseña"
+	},
+	"LoginForm": {
+		"description": "Buscamos simplificar la gestión del transporte público con herramientas digitales estables e intuitivas.",
+		"error": {
+			"description": "Se produjo un error al intentar iniciar sesión",
+			"title": "Error al intentar iniciar sesión"
+		},
+		"fields": {
+			"email": {
+				"placeholder": "Email"
+			},
+			"password": {
+				"placeholder": "Contraseña"
+			}
+		},
+		"footer": {
+			"label": "Recuperar contraseña"
+		},
+		"submit": {
+			"label": "Iniciar sesión"
+		},
+		"success": {
+			"description": "Inicio de sesión realizado correctamente",
+			"title": "Éxito"
+		},
+		"title": "Iniciar sesión en GO+"
+	},
+	"SendPasswordResetEmailForm": {
+		"description": "Introduzca su email para recuperar su contraseña",
+		"error": {
+			"description": "Se produjo un error al intentar enviar el email",
+			"title": "Error al intentar enviar el email"
+		},
+		"fields": {
+			"email": {
+				"placeholder": "Email de recuperación"
+			}
+		},
+		"footer": {
+			"label": "Volver al inicio de sesión"
+		},
+		"submit": {
+			"label": "Enviar email"
+		},
+		"success": {
+			"description": "Email de recuperación enviado correctamente",
+			"title": "Éxito"
+		},
+		"title": "Recuperar contraseña"
+	}
+}

--- a/modules/auth/apps/frontend/src/i18n/resources.ts
+++ b/modules/auth/apps/frontend/src/i18n/resources.ts
@@ -1,8 +1,10 @@
 'use client';
 
+import namespaceDefaultEs from '@/i18n/namespaces/default/es.json' with { type: 'json' };
 import namespaceDefaultPt from '@/i18n/namespaces/default/pt.json' with { type: 'json' };
+import namespaceUnauthenticatedEs from '@/i18n/namespaces/unauthenticated/es.json' with { type: 'json' };
 import namespaceUnauthenticatedPt from '@/i18n/namespaces/unauthenticated/pt.json' with { type: 'json' };
-import { i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
+import { i18nResourceKeysEsShared, i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
 
 /**
  * Resource keys for i18n translations in Portuguese.
@@ -15,4 +17,13 @@ export const i18nResourceKeysPt = {
 	...i18nResourceKeysPtShared,
 	default: namespaceDefaultPt,
 	unauthenticated: namespaceUnauthenticatedPt,
+} as const;
+
+/**
+ * Resource keys for i18n translations in Spanish.
+ */
+export const i18nResourceKeysEs = {
+	...i18nResourceKeysEsShared,
+	default: namespaceDefaultEs,
+	unauthenticated: namespaceUnauthenticatedEs,
 } as const;

--- a/modules/controller/apps/frontend/src/app/layout.tsx
+++ b/modules/controller/apps/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 /* * */
 
 import pjson from '#/package.json';
-import { i18nResourceKeysPt } from '@/i18n/resources';
+import { i18nResourceKeysEs, i18nResourceKeysPt } from '@/i18n/resources';
 import { DataProviders } from '@/providers/data-providers';
 import { AppProvider, AppWrapper, BaseProvider } from '@tmlmobilidade/ui';
 import { type Metadata } from 'next';
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: PropsWithChildren) {
 	return (
-		<BaseProvider i18n={{ pt: i18nResourceKeysPt }} version={pjson.version}>
+		<BaseProvider i18n={{ es: i18nResourceKeysEs, pt: i18nResourceKeysPt }} version={pjson.version}>
 			<AppProvider>
 				<DataProviders>
 					<AppWrapper>

--- a/modules/controller/apps/frontend/src/i18n/namespaces/default/es.json
+++ b/modules/controller/apps/frontend/src/i18n/namespaces/default/es.json
@@ -1,0 +1,637 @@
+{
+	"list": {
+		"RidesList": {
+			"columns": {
+				"analysis_ended_at_last_stop_grade": {
+					"label": "Last Stop"
+				},
+				"analysis_expected_apex_validation_interval_grade": {
+					"label": "Int. APEX"
+				},
+				"analysis_simple_three_vehicle_events_grade": {
+					"label": "3 Eventos"
+				},
+				"analysis_transaction_sequentiality": {
+					"label": "Seq.APEX"
+				},
+				"driver_ids": {
+					"label": "Driver IDs"
+				},
+				"duration_observed": {
+					"label": "Observado"
+				},
+				"duration_scheduled": {
+					"label": "Duración"
+				},
+				"end_time_observed": {
+					"label": "Observado"
+				},
+				"end_time_scheduled": {
+					"label": "Llegada"
+				},
+				"favorites": {
+					"label": "Favoritos"
+				},
+				"headsign": {
+					"label": "Pattern"
+				},
+				"operational_date": {
+					"label": "Fecha operacional"
+				},
+				"operational_status": {
+					"label": "Estado"
+				},
+				"passengers_observed": {
+					"label": "Pax"
+				},
+				"seen_last_at": {
+					"label": ""
+				},
+				"start_time_observed": {
+					"label": "Observado"
+				},
+				"start_time_scheduled": {
+					"label": "Salida"
+				},
+				"vehicle_ids": {
+					"label": "Vehicle IDs"
+				}
+			}
+		},
+		"RidesListFilterAcceptanceStatus": {
+			"label": "Aceptación"
+		},
+		"RidesListFilterAgency": {
+			"label": "Operador"
+		},
+		"RidesListFilterAnalysisEndedAtLastStop": {
+			"label": "Fin en la última parada"
+		},
+		"RidesListFilterAnalysisExpectedApexValidationInterval": {
+			"label": "Intervalo de validaciones"
+		},
+		"RidesListFilterAnalysisSimpleThreeEvents": {
+			"label": "3 momentos"
+		},
+		"RidesListFilterAnalysisTransactionSequentiality": {
+			"label": "Secuencialidad APEX"
+		},
+		"RidesListFilterDateRange": {
+			"label": "Intervalo de fechas"
+		},
+		"RidesListFilterDelayStatus": {
+			"label": "Retraso"
+		},
+		"RidesListFilterOperationalStatus": {
+			"label": "Estado"
+		},
+		"RidesListFilterTicketingStatus": {
+			"label": "Billeteo",
+			"options": {
+				"has_ticketing": "Con billeteo",
+				"no_ticketing": "Sin billeteo"
+			}
+		},
+		"RidesListHeader": {
+			"export": "Exportar circulaciones",
+			"title": "Circulaciones"
+		},
+		"RidesListLastUpdatedAt": {
+			"just_now": "Ahora mismo"
+		}
+	},
+	"rides": {
+		"acceptance": {
+			"RideAcceptance": {
+				"title": "Actividad"
+			},
+			"RideAcceptanceCommentList": {
+				"acceptance_status": {
+					"accepted": "La aceptación está aceptada",
+					"justification_required": "Es necesario justificar la circulación",
+					"rejected": "La aceptación está rechazada",
+					"under_review": "La aceptación está en revisión"
+				},
+				"crud": {
+					"archive": "La aceptación fue archivada",
+					"create": "La aceptación fue creada por el sistema",
+					"delete": "La aceptación fue eliminada",
+					"restore": "La aceptación fue restaurada",
+					"update": "La aceptación fue actualizada"
+				},
+				"justification": {
+					"updated": "La justificación fue actualizada"
+				},
+				"lock": {
+					"lock": "La aceptación fue bloqueada",
+					"unlock": "La aceptación fue desbloqueada"
+				},
+				"note": {
+					"created": "La aceptación fue creada por el sistema"
+				},
+				"summary": {
+					"performed": "Se realizó un nuevo análisis del viaje"
+				}
+			},
+			"RideAcceptanceJustification": {
+				"SubmitButton": {
+					"label": "Justificar"
+				},
+				"fields": {
+					"cause": {
+						"label": "Motivo de la justificación",
+						"placeholder": "Seleccione el motivo de la justificación"
+					},
+					"manual_trip_id": {
+						"label": "ID del viaje manual (opcional)"
+					},
+					"message": {
+						"label": "Mensaje de justificación"
+					}
+				},
+				"readonly": {
+					"cause": {
+						"label": "Motivo de la justificación"
+					},
+					"manual_trip_id": {
+						"label": "ID del viaje manual"
+					},
+					"message": {
+						"label": "Mensaje de justificación"
+					}
+				},
+				"title": "Justificación"
+			}
+		},
+		"analysis": {
+			"RideAnalysisApexLocations": {
+				"Table": {
+					"columns": {
+						"created_at": {
+							"label": "Timestamp"
+						},
+						"id_apex_location": {
+							"label": "ID Apex Location"
+						},
+						"mac_sam_serial_number": {
+							"label": "SAM SN"
+						},
+						"stop_id": {
+							"label": "Stop ID"
+						},
+						"vehicle_id": {
+							"label": "Vehicle ID"
+						}
+					}
+				},
+				"description": "Localizaciones APEX asociadas a esta Ride.",
+				"no_data": "Ninguna localización APEX registrada",
+				"title": "APEX Locations"
+			},
+			"RideAnalysisApexOnBoardRefunds": {
+				"Table": {
+					"columns": {
+						"card_serial_number": {
+							"label": "Card SN"
+						},
+						"card_type": {
+							"label": "Card Type"
+						},
+						"created_at": {
+							"label": "Timestamp"
+						},
+						"id_on_board_refund": {
+							"label": "ID On Board Refund"
+						},
+						"id_on_board_sale": {
+							"label": "ID On Board Sale"
+						},
+						"id_validation": {
+							"label": "ID Validation"
+						},
+						"payment_method": {
+							"label": "Payment Method"
+						},
+						"price": {
+							"label": "Price"
+						},
+						"product_id": {
+							"label": "Product ID"
+						},
+						"product_quantity": {
+							"label": "Cant."
+						},
+						"stop_id": {
+							"label": "Stop ID"
+						}
+					}
+				},
+				"description": "Reembolsos APEX asociados a esta Ride.",
+				"no_data": "Ningún reembolso registrado",
+				"title": "APEX On Board Refunds"
+			},
+			"RideAnalysisApexOnBoardSales": {
+				"Table": {
+					"columns": {
+						"card_serial_number": {
+							"label": "Card SN"
+						},
+						"card_type": {
+							"label": "Card Type"
+						},
+						"created_at": {
+							"label": "Timestamp"
+						},
+						"id_on_board_refund": {
+							"label": "ID On Board Refund"
+						},
+						"id_on_board_sale": {
+							"label": "ID On Board Sale"
+						},
+						"id_validation": {
+							"label": "ID Validation"
+						},
+						"payment_method": {
+							"label": "Payment Method"
+						},
+						"price": {
+							"label": "Price"
+						},
+						"product_id": {
+							"label": "Product ID"
+						},
+						"product_quantity": {
+							"label": "Cant."
+						},
+						"stop_id": {
+							"label": "Stop ID"
+						}
+					}
+				},
+				"description": "Ventas APEX asociadas a esta Ride.",
+				"no_data": "Ninguna venta registrada",
+				"title": "APEX On Board Sales"
+			},
+			"RideAnalysisApexValidations": {
+				"Table": {
+					"columns": {
+						"card_serial_number": {
+							"label": "Card SN"
+						},
+						"created_at": {
+							"label": "Timestamp"
+						},
+						"event_type": {
+							"label": "Event Type"
+						},
+						"id_on_board_refund": {
+							"label": "ID On Board Refund"
+						},
+						"id_on_board_sale": {
+							"label": "ID On Board Sale"
+						},
+						"id_validation": {
+							"label": "ID Validation"
+						},
+						"mac_sam_serial_number": {
+							"label": "SAM SN"
+						},
+						"product_id": {
+							"label": "Product ID"
+						},
+						"status": {
+							"label": "Status"
+						},
+						"stop_id": {
+							"label": "Stop ID"
+						},
+						"tx_valid": {
+							"label": "Tx Valid"
+						},
+						"vehicle_id": {
+							"label": "Vehicle ID"
+						}
+					}
+				},
+				"description": "Validaciones APEX asociadas a esta Ride.",
+				"no_data": "Ninguna validación registrada",
+				"title": "Validaciones APEX"
+			},
+			"RideAnalysisMap": {
+				"description": "Eventos de los vehículos mapeados",
+				"switches": {
+					"geofences": {
+						"label": "Geofences"
+					},
+					"observed_path": {
+						"label": "Recorrido observado"
+					},
+					"scheduled_path": {
+						"label": "Recorrido planificado"
+					}
+				},
+				"title": "Visión geográfica"
+			},
+			"RideAnalysisMetadata": {
+				"description": "Información general sobre esta circulación",
+				"fields": {
+					"apex_validations_qty": {
+						"label": "Validaciones (APEX TXs)"
+					},
+					"driver_ids": {
+						"label": "IDs de los conductores"
+					},
+					"end_delay": {
+						"label": "Retraso a la llegada"
+					},
+					"observed_end_time": {
+						"label": "Hora de fin observada"
+					},
+					"observed_start_time": {
+						"label": "Hora de inicio observada"
+					},
+					"on_board_sales": {
+						"label": "Ventas a bordo"
+					},
+					"operational_date": {
+						"label": "Día operacional"
+					},
+					"passengers": {
+						"label": "Pasajeros"
+					},
+					"pattern_id": {
+						"label": "ID del patrón"
+					},
+					"prepaid_validations": {
+						"label": "Validaciones prepago"
+					},
+					"scheduled_end_time": {
+						"label": "Hora de fin planificada"
+					},
+					"scheduled_start_time": {
+						"label": "Hora de inicio planificada"
+					},
+					"start_delay": {
+						"label": "Retraso a la salida"
+					},
+					"subscription_validations_qty": {
+						"label": "Validaciones de abonos"
+					},
+					"trip_id": {
+						"label": "ID del viaje"
+					},
+					"vehicle_ids": {
+						"label": "IDs de los vehículos"
+					}
+				},
+				"title": "Metadatos"
+			},
+			"RideAnalysisPerformance": {
+				"description": "Datos de rendimiento de la circulación",
+				"no_data": "Sin datos",
+				"title": "Performance"
+			},
+			"RideAnalysisResult": {
+				"description": "Eventos de los vehículos mapeados",
+				"labels": {
+					"AT_LEAST_ONE_VEHICLE_EVENT_ON_FIRST_STOP": {
+						"description": "Una circulación debe tener al menos un evento en la primera parada.",
+						"title": "Al menos un evento en la primera parada"
+					},
+					"ENDED_AT_LAST_STOP": {
+						"description": "Una circulación debe terminar en la última parada.",
+						"title": "Terminó en la última parada"
+					},
+					"EXPECTED_APEX_VALIDATION_INTERVAL": {
+						"description": "El intervalo entre validaciones es orgánico y representa la variación natural de los tiempos de validación de los pasajeros.",
+						"title": "Intervalo de validaciones APEX"
+					},
+					"EXPECTED_DRIVER_ID_QTY": {
+						"description": "Una circulación puede tener como máximo dos IDs de conductor diferentes.",
+						"title": "Como máximo dos conductores"
+					},
+					"EXPECTED_START_TIME": {
+						"description": "Una circulación debe comenzar después de la hora planificada y con un retraso inferior a 5 minutos.",
+						"title": "Inicio a tiempo"
+					},
+					"EXPECTED_VEHICLE_EVENT_DELAY": {
+						"description": "Los eventos no deben entregarse con más de 10 segundos después de su generación.",
+						"title": "Retraso excesivo en la entrega de los eventos"
+					},
+					"EXPECTED_VEHICLE_EVENT_INTERVAL": {
+						"description": "El intervalo medio entre eventos no debe exceder los 20 segundos.",
+						"title": "Intervalo medio entre eventos"
+					},
+					"EXPECTED_VEHICLE_EVENT_QTY": {
+						"description": "Una circulación debe tener al menos 10 eventos de vehículo.",
+						"title": "Menos de 10 eventos de vehículo"
+					},
+					"EXPECTED_VEHICLE_ID_QTY": {
+						"description": "Una circulación puede tener como máximo dos IDs de vehículo diferentes.",
+						"title": "Como máximo dos vehículos"
+					},
+					"MATCHING_APEX_LOCATIONS": {
+						"description": "Las transacciones de localización deben corresponder a los eventos de vehículo.",
+						"title": "Transacciones de localización correspondientes"
+					},
+					"MATCHING_VEHICLE_IDS": {
+						"description": "Los IDs de los vehículos recibidos en los eventos deben corresponder al ID de las transacciones APEX.",
+						"title": "Vehicle IDs correspondientes"
+					},
+					"SIMPLE_ONE_APEX_VALIDATION": {
+						"description": "Una circulación debe tener al menos una transacción de validación.",
+						"title": "Al menos una transacción de validación"
+					},
+					"SIMPLE_ONE_VEHICLE_EVENT_OR_APEX_VALIDATION": {
+						"description": "Una circulación debe tener al menos un evento o una transacción de validación.",
+						"title": "Al menos un evento o una transacción de validación"
+					},
+					"SIMPLE_THREE_VEHICLE_EVENTS": {
+						"description": "Una circulación debe tener al menos tres eventos al inicio, en el medio y al final del viaje.",
+						"title": "Al menos tres eventos"
+					},
+					"TRANSACTION_SEQUENTIALITY": {
+						"description": "Todas las transacciones generadas por el validador fueron entregadas.",
+						"title": "Secuencialidad de las transacciones APEX"
+					}
+				},
+				"no_data": "Sin datos",
+				"title": "Resultados de los análisis"
+			},
+			"RideAnalysisResultItem": {
+				"statuses": {
+					"fail": "Fail",
+					"failed": "Error",
+					"pass": "Pass"
+				}
+			},
+			"RideAnalysisVehicleEvents": {
+				"Table": {
+					"columns": {
+						"_id": {
+							"label": "ID"
+						},
+						"activity": {
+							"label": "Actividad"
+						},
+						"created_at": {
+							"label": "Timestamp"
+						},
+						"door": {
+							"label": "Puerta"
+						},
+						"driver_id": {
+							"label": "ID del conductor"
+						},
+						"latitude": {
+							"label": "Latitud"
+						},
+						"longitude": {
+							"label": "Longitud"
+						},
+						"odometer": {
+							"label": "Odómetro"
+						},
+						"stop_id": {
+							"label": "ID de la parada"
+						},
+						"vehicle_id": {
+							"label": "ID del vehículo"
+						}
+					}
+				},
+				"description": "Eventos GTFS-RT generados por el vehículo.",
+				"title": "Eventos del vehículo"
+			}
+		},
+		"detail": {
+			"RidesDetailAcceptanceStatusTag": {
+				"accepted": "Aceptada",
+				"justification_required": "Justificación necesaria",
+				"rejected": "Rechazada",
+				"under_review": "En revisión"
+			},
+			"RidesDetailAnalysisStatusTag": {
+				"fail": "Fail",
+				"pass": "Pass"
+			}
+		},
+		"export": {
+			"RidesExportModal": {
+				"CancelButton": {
+					"label": "Cancelar"
+				},
+				"ExportButton": {
+					"label": "Exportar circulaciones"
+				},
+				"description": "Seleccione el intervalo de fechas para la exportación de las circulaciones.",
+				"fields": {
+					"end_date": {
+						"placeholder": "Fecha fin"
+					},
+					"start_date": {
+						"placeholder": "Fecha inicio"
+					}
+				},
+				"title": "Exportar circulaciones"
+			}
+		}
+	},
+	"sams": {
+		"detail": {
+			"SamsDetailBasicInfos": {
+				"description": "Información básica del SAM",
+				"fields": {
+					"agency_id": {
+						"label": "Operador"
+					},
+					"latest_apex_version": {
+						"label": "Versión APEX utilizada"
+					},
+					"seen_first_at": {
+						"label": "Primera vista"
+					},
+					"seen_last_at": {
+						"label": "Última vista"
+					},
+					"status": {
+						"label": "Estado del SAM"
+					},
+					"system_status": {
+						"label": "Estado del SAM en el sistema"
+					},
+					"transactions_expected": {
+						"label": "Transacciones esperadas"
+					},
+					"transactions_found": {
+						"label": "Transacciones encontradas"
+					},
+					"transactions_missing": {
+						"label": "Transacciones faltantes"
+					}
+				},
+				"title": "Información básica"
+			},
+			"SamsDetailCalendar": {
+				"day": {
+					"label": "Diario"
+				},
+				"description": "Calendario de los análisis del SAM",
+				"month": {
+					"label": "Mensual"
+				},
+				"title": "Calendario de análisis"
+			},
+			"SamsDetailList": {
+				"SamsDetailListFilterApexVersion": {
+					"label": "Versión APEX (transacciones)"
+				},
+				"SamsDetailListFilterDate": {
+					"label": "Intervalo de análisis"
+				},
+				"description": "Lista de análisis realizados del SAM",
+				"title": "Lista de análisis"
+			}
+		},
+		"export": {
+			"SamsExportModal": {
+				"ExportButton": {
+					"label": "Exportar análisis"
+				},
+				"title": "Exportar análisis"
+			}
+		},
+		"list": {
+			"SamsFiltersApexVersion": {
+				"label": "Versión APEX"
+			},
+			"SamsFiltersDate": {
+				"label": "Fechas de visualización"
+			},
+			"SamsFiltersStatus": {
+				"label": "Estado",
+				"options": {
+					"complete": "Completo",
+					"error": "Error",
+					"incomplete": "Incompleto",
+					"waiting": "En espera"
+				}
+			},
+			"SamsListFilterAgency": {
+				"label": "Operador"
+			},
+			"SamsListFilterFavorites": {
+				"label": "Favoritos"
+			},
+			"SamsListHeader": {
+				"title": "SAMs"
+			},
+			"SamsListStatus": {
+				"completed": "Completo",
+				"failed": "Falló",
+				"processing": "En procesamiento",
+				"waiting": "En espera"
+			}
+		}
+	}
+}

--- a/modules/controller/apps/frontend/src/i18n/namespaces/ride-analysis/es.json
+++ b/modules/controller/apps/frontend/src/i18n/namespaces/ride-analysis/es.json
@@ -1,0 +1,62 @@
+{
+	"AT_LEAST_ONE_VEHICLE_EVENT_ON_FIRST_STOP": {
+		"description": "Una circulación debe tener al menos un evento en la primera parada.",
+		"label": "Al menos un evento en la primera parada"
+	},
+	"ENDED_AT_LAST_STOP": {
+		"description": "Una circulación debe terminar en la última parada.",
+		"label": "Terminó en la última parada"
+	},
+	"EXPECTED_APEX_VALIDATION_INTERVAL": {
+		"description": "El intervalo entre validaciones es orgánico y representa la variación natural de los tiempos de validación de los pasajeros.",
+		"label": "Intervalo de validaciones APEX"
+	},
+	"EXPECTED_DRIVER_ID_QTY": {
+		"description": "Una circulación puede tener como máximo dos IDs de conductor diferentes.",
+		"label": "Como máximo dos conductores"
+	},
+	"EXPECTED_START_TIME": {
+		"description": "Una circulación debe comenzar después de la hora planificada y con un retraso inferior a 5 minutos.",
+		"label": "Inicio a tiempo"
+	},
+	"EXPECTED_VEHICLE_EVENT_DELAY": {
+		"description": "Los eventos no deben entregarse con más de 10 segundos después de su generación.",
+		"label": "Retraso excesivo en la entrega de los eventos"
+	},
+	"EXPECTED_VEHICLE_EVENT_INTERVAL": {
+		"description": "El intervalo medio entre eventos no debe exceder los 20 segundos.",
+		"label": "Intervalo medio entre eventos"
+	},
+	"EXPECTED_VEHICLE_EVENT_QTY": {
+		"description": "Una circulación debe tener al menos 10 eventos de vehículo.",
+		"label": "Menos de 10 eventos de vehículo"
+	},
+	"EXPECTED_VEHICLE_ID_QTY": {
+		"description": "Una circulación puede tener como máximo dos IDs de vehículo diferentes.",
+		"label": "Como máximo dos vehículos"
+	},
+	"MATCHING_APEX_LOCATIONS": {
+		"description": "Las transacciones de localización deben corresponder a los eventos de vehículo.",
+		"label": "Transacciones de localización correspondientes"
+	},
+	"MATCHING_VEHICLE_IDS": {
+		"description": "Los IDs de los vehículos recibidos en los eventos deben corresponder al ID de las transacciones APEX.",
+		"label": "Vehicle IDs correspondientes"
+	},
+	"SIMPLE_ONE_APEX_VALIDATION": {
+		"description": "Una circulación debe tener al menos una transacción de validación.",
+		"label": "Al menos una transacción de validación"
+	},
+	"SIMPLE_ONE_VEHICLE_EVENT_OR_APEX_VALIDATION": {
+		"description": "Una circulación debe tener al menos un evento o una transacción de validación.",
+		"label": "Al menos un evento o una transacción de validación"
+	},
+	"SIMPLE_THREE_VEHICLE_EVENTS": {
+		"description": "Una circulación debe tener al menos tres eventos al inicio, en el medio y al final del viaje.",
+		"label": "Al menos tres eventos"
+	},
+	"TRANSACTION_SEQUENTIALITY": {
+		"description": "Todas las transacciones generadas por el validador fueron entregadas.",
+		"label": "Secuencialidad de las transacciones APEX"
+	}
+}

--- a/modules/controller/apps/frontend/src/i18n/namespaces/ride-status/es.json
+++ b/modules/controller/apps/frontend/src/i18n/namespaces/ride-status/es.json
@@ -1,0 +1,9 @@
+{
+	"acceptance_status": {
+		"accepted": "Aceptada",
+		"justification_required": "Justificación necesaria",
+		"none": "(sin valor)",
+		"rejected": "Rechazada",
+		"under_review": "En revisión"
+	}
+}

--- a/modules/controller/apps/frontend/src/i18n/resources.ts
+++ b/modules/controller/apps/frontend/src/i18n/resources.ts
@@ -1,9 +1,12 @@
 'use client';
 
+import namespaceDefaultEs from '@/i18n/namespaces/default/es.json' with { type: 'json' };
 import namespaceDefaultPt from '@/i18n/namespaces/default/pt.json' with { type: 'json' };
+import namespaceAnalysisEs from '@/i18n/namespaces/ride-analysis/es.json' with { type: 'json' };
 import namespaceAnalysisPt from '@/i18n/namespaces/ride-analysis/pt.json' with { type: 'json' };
+import namespaceStatusEs from '@/i18n/namespaces/ride-status/es.json' with { type: 'json' };
 import namespaceStatusPt from '@/i18n/namespaces/ride-status/pt.json' with { type: 'json' };
-import { i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
+import { i18nResourceKeysEsShared, i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
 
 /**
  * Resource keys for i18n translations in Portuguese.
@@ -17,4 +20,14 @@ export const i18nResourceKeysPt = {
 	default: namespaceDefaultPt,
 	ride_analysis: namespaceAnalysisPt,
 	ride_status: namespaceStatusPt,
+} as const;
+
+/**
+ * Resource keys for i18n translations in Spanish.
+ */
+export const i18nResourceKeysEs = {
+	...i18nResourceKeysEsShared,
+	default: namespaceDefaultEs,
+	ride_analysis: namespaceAnalysisEs,
+	ride_status: namespaceStatusEs,
 } as const;

--- a/modules/hub/apps/frontend-videowall/src/app/layout.tsx
+++ b/modules/hub/apps/frontend-videowall/src/app/layout.tsx
@@ -1,7 +1,7 @@
 /* * */
 
 import pjson from '#/package.json';
-import { i18nResourceKeysPt } from '@/i18n/resources';
+import { i18nResourceKeysEs, i18nResourceKeysPt } from '@/i18n/resources';
 import { BaseProvider } from '@tmlmobilidade/ui';
 import { type Metadata } from 'next';
 import { NuqsAdapter } from 'nuqs/adapters/react';
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: PropsWithChildren) {
 	return (
-		<BaseProvider i18n={{ pt: i18nResourceKeysPt }} version={pjson.version}>
+		<BaseProvider i18n={{ es: i18nResourceKeysEs, pt: i18nResourceKeysPt }} version={pjson.version}>
 			<NuqsAdapter>
 				{children}
 			</NuqsAdapter>

--- a/modules/hub/apps/frontend-videowall/src/i18n/namespaces/default/es.json
+++ b/modules/hub/apps/frontend-videowall/src/i18n/namespaces/default/es.json
@@ -1,0 +1,332 @@
+{
+	"action-bar": {
+		"ActionBar": {
+			"alerts": {
+				"label": "Alertas de servicio"
+			},
+			"help": {
+				"label": "Preguntas frecuentes"
+			},
+			"reload": {
+				"label": "Recargar"
+			},
+			"search": {
+				"label": "Buscar"
+			}
+		},
+		"ActionBarUserLocation": {
+			"disabled": {
+				"label": "Ubicación desactivada"
+			},
+			"follow": {
+				"label": "Orientar mapa"
+			},
+			"follow-bearing": {
+				"label": "Centrar mapa"
+			},
+			"idle": {
+				"label": "Centrar mapa"
+			}
+		}
+	},
+	"alerts": {
+		"AlertActivePeriod": {
+			"start": "Inicio: {value, date, dayShort}"
+		},
+		"AlertsList": {
+			"title": "Alertas de servicio"
+		},
+		"AlertsListEmpty": {
+			"action_1": "Ver alertas del pasado",
+			"action_2": "Ver alertas del futuro",
+			"subtitle": "Manténgase al día de todos los cambios en la red. Infórmese sobre nuevas líneas, cambios de recorrido y ajustes de horarios, así como sobre eventos que puedan afectar a su viaje.",
+			"title": "No se encontraron alertas"
+		},
+		"AlertsListGroup": {
+			"label": "{count, plural, one {Alerta activa} other {Alertas activas}}",
+			"titles": {
+				"future": "A partir de {value}",
+				"past": "Desde {value}",
+				"today": "A partir de hoy, {value}",
+				"tomorrow": "A partir de mañana, {value}",
+				"yesterday": "Desde ayer, {value}"
+			}
+		},
+		"AlertsListToolbar": {
+			"SelectLine": {
+				"label": "Buscar línea por número, nombre, localidad...",
+				"nothing_found": "No se encontraron resultados",
+				"placeholder": "Buscar línea por número, nombre, localidad..."
+			},
+			"SelectStop": {
+				"label": "Buscar parada por nombre, número, localidad...",
+				"nothing_found": "No se encontraron resultados",
+				"placeholder": "Buscar parada por nombre, número, localidad..."
+			},
+			"by_date": {
+				"current": "Ahora ({count})",
+				"future": "Futuros ({count})",
+				"map": "Mapa"
+			},
+			"expand_toggle": {
+				"is_hidden": {
+					"label": "Ver filtros"
+				},
+				"is_visible": {
+					"label": "Ocultar filtros"
+				}
+			},
+			"filters": {
+				"by_current_view": {
+					"list": "Lista",
+					"map": "Mapa"
+				},
+				"by_line": {
+					"label": "Filtrar por línea",
+					"placeholder": "Filtrar por línea"
+				},
+				"by_stop": {
+					"label": "Filtrar por parada",
+
+					"placeholder": "Filtrar por parada"
+				},
+				"text_search": "Buscar alerta por título, descripción, ubicación..."
+			},
+			"found_items_counter": "{count, plural, =0 {No se encontraron alertas.} one {Se encontró # alerta:} other {Se encontraron # alertas:}}",
+			"heading": "Alertas de servicio",
+			"subheading": "Manténgase al día de todos los cambios en la red. Infórmese sobre nuevas líneas, cambios de recorrido y ajustes de horarios, así como sobre eventos que puedan afectar a su viaje."
+		},
+		"AlertsListViewList": {
+			"no_data": "No se encontraron alertas para esta búsqueda"
+		},
+		"SelectCause": {
+			"placeholder": "Filtrar por causa"
+		},
+		"SelectEffect": {
+			"placeholder": "Filtrar por efecto"
+		}
+	},
+	"common": {
+		"BackButton": {
+			"label": "Volver"
+		},
+		"IconDisplay": {
+			"connections": {
+				"bike_parking": "Cerca de aparcamiento de bicicletas",
+				"boat": "Conexión con barco",
+				"bus": "Conexión con otros autobuses",
+				"car_parking": "Cerca de aparcamiento de coches",
+				"light_rail": "Conexión con metro ligero",
+				"subway": "Conexión con metro",
+				"train": "Conexión con tren"
+			},
+			"facilities": {
+				"court": "Cerca de un juzgado",
+				"fire_station": "Cerca de un parque de bomberos",
+				"health_center": "Cerca de un centro de salud o clínica",
+				"hospital": "Cerca de un hospital",
+				"park": "Cerca de un parque",
+				"police_station": "Cerca de una comisaría de policía",
+				"school": "Cerca de una escuela",
+				"transit_office": "Cerca de un espacio navegante®",
+				"university": "Cerca de una universidad"
+			},
+			"operators": {
+				"atlantic_ferries": "Atlantic Ferries (barcos de Tróia)",
+				"ccfl": "Carris municipal",
+				"cmet": "CMET",
+				"cp": "CP Comboios de Portugal",
+				"fertagus": "Fertagus (tren del puente)",
+				"metro": "Metro de Lisboa",
+				"mobi_cascais": "MobiCascais",
+				"mts": "Metro Transportes do Sul",
+				"tcb": "Transportes Colectivos do Barreiro",
+				"ttsl": "Transtejo e Soflusa"
+			}
+		}
+	},
+	"help": {
+		"HelpDetail": {
+			"no_data": "No hay preguntas frecuentes disponibles en este momento.",
+			"title": "Ayuda"
+		}
+	},
+	"layout": {
+		"NoDataLabel": {
+			"no_data": "No hay datos disponibles"
+		}
+	},
+	"lines": {
+		"LinesDetailAlerts": {
+			"heading": "Alertas activas para esta línea"
+		},
+		"LinesDetailPath": {
+			"no_data": "Seleccione un recorrido / destino",
+			"stop_details_name": "{index}ª parada: {stop_name}",
+			"summary": "Línea <lineNumber>{line_number}</lineNumber> con destino a <destinationName>{destination_name}</destinationName> el día <dayName>{day_name, date, long}</dayName>. <changeDay>Cambiar día ›</changeDay>",
+			"view_stop_details": "Ver detalles de la parada"
+		},
+		"LinesListGroup": {
+			"logo": {
+				"alt": "Líneas de: {agency_name}"
+			},
+			"show_more": "Ver más líneas de este operador..."
+		},
+		"LinesListToolbar": {
+			"by_search": {
+				"placeholder": "Buscar por nombre, número..."
+			},
+			"found_items_counter": {
+				"all": "{count, plural, =0 {No se encontraron líneas.} one {Se encontró # línea:} other {Se encontraron # líneas:}}"
+			},
+			"heading": "Buscar líneas"
+		},
+		"LinesListViewAll": {
+			"items": {
+				"aria_label": "{index}º: {tts_name}"
+			},
+			"no_data": "No se encontraron líneas para esta búsqueda"
+		},
+		"PathStopNextArrivals": {
+			"title": "Próximas circulaciones"
+		},
+		"PathWaypointTimetable": {
+			"next_date": "Esta línea no realiza viajes en este día de la semana. Próximo día con horarios: {value, date, dayShort} {value, date, monthLong} {value, date, yearLong}",
+			"no_data": "Horarios no disponibles para esta fecha.",
+			"title": "Horarios planificados en esta parada:"
+		},
+		"SelectActivePatternGroup": {
+			"placeholder": "Seleccionar recorrido/destino..."
+		},
+		"SelectActivePatternGroupExplainer": {
+			"toggle": "¿Qué es el recorrido/destino de una línea?"
+		},
+		"SelectOperationalDate": {
+			"custom_date": "Fecha personalizada",
+			"today": "Hoy",
+			"tomorrow": "Mañana"
+		},
+		"SelectPattern": {
+			"invalid_option": "Recorrido inválido: {pattern_id}",
+			"label": "Recorrido / Destino",
+			"option_label": "Inicio del recorrido: {locality}",
+			"placeholder": "Seleccionar recorrido / destino..."
+		},
+		"TimetableExceptionsLink": {
+			"schedule": "Min.",
+			"variant": "<0>{exception_id})</0> Recorrido <1>{route_long_name}</1> con destino a <2>{pattern_headsign}</2>"
+		},
+		"TimetableSchedules": {
+			"hours": "Hora",
+			"minutes": "Min.",
+			"timestamp": "{hour} horas y {minute} minutos"
+		}
+	},
+	"map": {
+		"MapViewToolbar": {
+			"style": {
+				"map": "Mapa",
+				"satellite": "Satélite"
+			}
+		}
+	},
+	"search": {
+		"SearchDetail": {
+			"title": "Búsqueda"
+		},
+		"SearchToolbar": {
+			"types": {
+				"alerts": "Alertas",
+				"lines": "Líneas",
+				"stops": "Paradas"
+			}
+		}
+	},
+	"stops": {
+		"NextArrivals": {
+			"arriving": "Llegando",
+			"hours": "h",
+			"minutes": "min"
+		},
+		"StopsDetail": {
+			"title": "Parada"
+		},
+		"StopsDetailAlerts": {
+			"heading": "Alertas activas",
+			"subheading": "Alertas activas para esta parada o para líneas que pasan por esta parada."
+		},
+		"StopsDetailContentTimetableHeader": {
+			"summary": "Horarios estimados de paso en la parada <stopName>{stop_name}</stopName> para el día <dayName>{day_name, date, long}</dayName>. <changeDay>Cambiar día ›</changeDay>",
+			"trips_legend": {
+				"estimate": "Previsión",
+				"headsign": "Destino",
+				"line": "Línea"
+			}
+		},
+		"StopsDetailViewTimetable": {
+			"end_of_day": "Fin del día",
+			"no_service": "Sin servicio para el día seleccionado",
+			"show_past_trips_toggle": {
+				"hide": "Ocultar pasajes anteriores",
+				"show": "Ver pasajes anteriores"
+			}
+		},
+		"StopsDetailViewTimetableRow": {
+			"localities": "Pasa por: {localities}"
+		},
+		"StopsListToolbar": {
+			"by_current_view": {
+				"list": "Lista",
+				"map": "Mapa"
+			},
+			"by_search": {
+				"placeholder": "Buscar por nombre, número..."
+			},
+			"found_items_counter": {
+				"all": "{{count}}"
+			},
+			"heading": "Buscar paradas"
+		},
+		"StopsListViewList": {
+			"no_data": "No se encontraron paradas para esta búsqueda"
+		}
+	},
+	"vehicles": {
+		"VehiclesCounter": {
+			"label": "{count, plural, zero {Ningún vehículo en movimiento} one {# vehículo en movimiento} other {# vehículos en movimiento}}"
+		},
+		"VehiclesDetail": {
+			"title": "Vehículo"
+		},
+		"VehiclesDetailView": {
+			"seen_seconds_ago": "Visto hace {count, plural, one {# segundo} other {# segundos}}"
+		},
+		"VehiclesListDetails": {
+			"bikes_allowed": "Permite bicicletas",
+			"contactless": "Acepta pagos contactless",
+			"no_bikes_allowed": "No permite bicicletas",
+			"no_contactless": "No acepta pagos contactless",
+			"no_data": "Seleccione un vehículo",
+			"no_wheelchair_accessible": "No permite movilidad reducida",
+			"unknown": "Desconocido",
+			"wheelchair_accessible": "Movilidad reducida"
+		}
+	},
+	"viewport": {
+		"NavigationBar": {
+			"tabs": {
+				"alerts": "Alertas",
+				"lines": "Líneas",
+				"stops": "Paradas"
+			}
+		},
+		"TransitModesBar": {
+			"aria_label": {
+				"bus": "Autobuses",
+				"ferry": "Barco",
+				"subway": "Metro",
+				"train": "Trenes"
+			}
+		}
+	}
+}

--- a/modules/hub/apps/frontend-videowall/src/i18n/resources.ts
+++ b/modules/hub/apps/frontend-videowall/src/i18n/resources.ts
@@ -1,7 +1,8 @@
 'use client';
 
+import namespaceDefaultEs from '@/i18n/namespaces/default/es.json' with { type: 'json' };
 import namespaceDefaultPt from '@/i18n/namespaces/default/pt.json' with { type: 'json' };
-import { i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
+import { i18nResourceKeysEsShared, i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
 
 /**
  * Resource keys for i18n translations in Portuguese.
@@ -13,4 +14,12 @@ import { i18nResourceKeysPtShared } from '@tmlmobilidade/ui';
 export const i18nResourceKeysPt = {
 	...i18nResourceKeysPtShared,
 	default: namespaceDefaultPt,
+} as const;
+
+/**
+ * Resource keys for i18n translations in Spanish.
+ */
+export const i18nResourceKeysEs = {
+	...i18nResourceKeysEsShared,
+	default: namespaceDefaultEs,
 } as const;

--- a/packages/ui/src/components/sidebar/SidebarExports/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarExports/index.tsx
@@ -3,6 +3,7 @@
 import { type MenuProps } from '@mantine/core';
 import { IconCloudDown, IconCloudMinus } from '@tabler/icons-react';
 import { type FileExport } from '@tmlmobilidade/types';
+import { useTranslation } from 'react-i18next';
 
 import { useExportsContext } from '../../../contexts/exports.context';
 import { Menu } from '../../menu/Menu';
@@ -30,6 +31,7 @@ export function SidebarExports({ menuPosition }: SidebarExportsProps = {}) {
 	//
 	// A. Setup variables
 
+	const { t } = useTranslation();
 	const exportsContext = useExportsContext();
 	const fileExports = exportsContext.data.fileExports || [];
 
@@ -37,10 +39,10 @@ export function SidebarExports({ menuPosition }: SidebarExportsProps = {}) {
 	// B. Render components
 
 	return (
-		<Menu counter={fileExports.length} icon={IconCloudDown} label="Exportações" menuPosition={menuPosition} variant="danger">
+		<Menu counter={fileExports.length} icon={IconCloudDown} label={t('shared:components.sidebar.SidebarExports.label')} menuPosition={menuPosition} variant="danger">
 			{fileExports.length === 0
-				? <MenuNoContent icon={IconCloudMinus} text="Sem exportações disponíveis" />
-				: <MenuList data={fileExports} getItemKey={item => item._id} itemComponent={SidebarExportsMenuItem} title="Exportações" />}
+				? <MenuNoContent icon={IconCloudMinus} text={t('shared:components.sidebar.SidebarExports.no_exports')} />
+				: <MenuList data={fileExports} getItemKey={item => item._id} itemComponent={SidebarExportsMenuItem} title={t('shared:components.sidebar.SidebarExports.title')} />}
 		</Menu>
 	);
 

--- a/packages/ui/src/components/sidebar/SidebarExportsItem/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarExportsItem/index.tsx
@@ -3,6 +3,7 @@
 import { IconCheck, IconCircleDashed, IconFileDownload, IconLoader2, IconX } from '@tabler/icons-react';
 import { FileExport } from '@tmlmobilidade/types';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import styles from './styles.module.css';
 
@@ -23,6 +24,7 @@ export function SidebarExportsItem({ fileExport }: SidebarExportsItemProps) {
 
 	//
 	// A. Setup variables
+	const { t } = useTranslation();
 	const exportsContext = useExportsContext();
 
 	const icon = useMemo(() => {
@@ -51,7 +53,7 @@ export function SidebarExportsItem({ fileExport }: SidebarExportsItemProps) {
 				<Section flexDirection="row" gap="sm" justifyContent="space-between" padding="none" width="fit-content">
 					<div className={styles.iconWrapper}>{icon}</div>
 					<div>
-						<Label size="md">{fileExport.file_name || 'Sem nome'}</Label>
+						<Label size="md">{fileExport.file_name || t('shared:components.sidebar.SidebarExportsItem.no_name')}</Label>
 						<div className={styles.body}>
 							<Label size="sm">{fileExport.processing_status}</Label>
 						</div>

--- a/packages/ui/src/components/sidebar/SidebarNotifications/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarNotifications/index.tsx
@@ -5,6 +5,7 @@
 import { type MenuProps } from '@mantine/core';
 import { IconBell, IconBellOff } from '@tabler/icons-react';
 import { type Notification } from '@tmlmobilidade/types';
+import { useTranslation } from 'react-i18next';
 
 import { useNotificationsContext } from '../../../contexts/Notifications.context';
 import { Menu } from '../../menu/Menu';
@@ -32,6 +33,7 @@ export function SidebarNotifications({ menuPosition }: SidebarNotificationsProps
 	//
 	// A. Setup variables
 
+	const { t } = useTranslation();
 	const notificationsContext = useNotificationsContext();
 
 	const notifications = notificationsContext.data.allNotifications || [];
@@ -42,13 +44,13 @@ export function SidebarNotifications({ menuPosition }: SidebarNotificationsProps
 	// B. Render components
 
 	return (
-		<Menu counter={unreadNotifications.length} icon={IconBell} label="Notificações" menuPosition={menuPosition} variant="danger">
+		<Menu counter={unreadNotifications.length} icon={IconBell} label={t('shared:components.sidebar.SidebarNotifications.label')} menuPosition={menuPosition} variant="danger">
 
-			<MenuList data={unreadNotifications} getItemKey={item => item._id} itemComponent={SidebarNotificationsMenuItem} title="Não Lidas" />
-			<MenuList data={readNotifications} getItemKey={item => item._id} itemComponent={SidebarNotificationsMenuItem} title="Lidas" />
+			<MenuList data={unreadNotifications} getItemKey={item => item._id} itemComponent={SidebarNotificationsMenuItem} title={t('shared:components.sidebar.SidebarNotifications.unread')} />
+			<MenuList data={readNotifications} getItemKey={item => item._id} itemComponent={SidebarNotificationsMenuItem} title={t('shared:components.sidebar.SidebarNotifications.read')} />
 
 			{notifications.length === 0 && (
-				<MenuNoContent icon={IconBellOff} text="Sem notificações disponíveis" />
+				<MenuNoContent icon={IconBellOff} text={t('shared:components.sidebar.SidebarNotifications.no_notifications')} />
 			)}
 		</Menu>
 	);

--- a/packages/ui/src/components/sidebar/SidebarNotificationsItem/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarNotificationsItem/index.tsx
@@ -2,6 +2,7 @@
 
 import { Notification } from '@tmlmobilidade/types';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import styles from './styles.module.css';
 
@@ -25,6 +26,7 @@ export function SidebarNotificationsItem({ notification }: SidebarNotificationsI
 	//
 	// A. Setup variables
 
+	const { t } = useTranslation();
 	const notificationsContext = useNotificationsContext();
 	const icon = getSidebarNotificationScopeIcon(notification.scope);
 
@@ -35,16 +37,16 @@ export function SidebarNotificationsItem({ notification }: SidebarNotificationsI
 	return (
 		<div className={styles.root}>
 			<div
-				aria-label="Marcar como lido"
+				aria-label={t('shared:components.sidebar.SidebarNotificationsItem.mark_as_read_aria')}
 				className={styles.left}
 				onClick={() => notificationsContext.actions.markAsRead(notification)}
 			>
 				<Section flexDirection="row" gap="sm" padding="none" width="fit-content">
 					<div className={styles.iconWrapper}>{icon && React.cloneElement(icon, { size: 20 })}</div>
 					<div>
-						<Label size="md">{notification.payload.title || 'Sem titulo'}</Label>
+						<Label size="md">{notification.payload.title || t('shared:components.sidebar.SidebarNotificationsItem.no_title')}</Label>
 						<div className={styles.body}>
-							<Label size="sm">{notification.payload.body || 'Sem Descrição'}</Label>
+							<Label size="sm">{notification.payload.body || t('shared:components.sidebar.SidebarNotificationsItem.no_description')}</Label>
 						</div>
 					</div>
 				</Section>

--- a/packages/ui/src/components/sidebar/SidebarOptions/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarOptions/index.tsx
@@ -2,6 +2,7 @@
 
 import { ColorSwatch, Menu as MantineMenu, type MenuProps } from '@mantine/core';
 import { IconBellRinging, IconBrightness, IconCheck, IconColorSwatch, IconLanguage, IconLogout, IconMaximize, IconMinimize, IconSettings } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
 
 import { AVAILABLE_MODES, AVAILABLE_THEMES, useLayoutContext } from '../../../contexts/Layout.context';
 import { useMeContext } from '../../../contexts/Me.context';
@@ -24,6 +25,7 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 	//
 	// A. Setup variables
 
+	const { t } = useTranslation();
 	const meContext = useMeContext();
 	const layoutContext = useLayoutContext();
 	const versionContext = useVersionContext();
@@ -33,14 +35,14 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 	// B. Render components
 
 	return (
-		<Menu icon={IconSettings} label="Definições" menuPosition={menuPosition}>
+		<Menu icon={IconSettings} label={t('shared:components.sidebar.SidebarOptions.label')} menuPosition={menuPosition}>
 
-			<MantineMenu.Label>Personalização</MantineMenu.Label>
+			<MantineMenu.Label>{t('shared:components.sidebar.SidebarOptions.customisation')}</MantineMenu.Label>
 
 			<MantineMenu.Sub position="left">
 				<MantineMenu.Sub.Target>
 					<MantineMenu.Sub.Item leftSection={<IconBrightness size={20} />}>
-						Modo
+						{t('shared:components.sidebar.SidebarOptions.mode')}
 					</MantineMenu.Sub.Item>
 				</MantineMenu.Sub.Target>
 				<MantineMenu.Sub.Dropdown>
@@ -60,7 +62,7 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 			<MantineMenu.Sub position="left">
 				<MantineMenu.Sub.Target>
 					<MantineMenu.Sub.Item leftSection={<IconColorSwatch size={20} />}>
-						Tema
+						{t('shared:components.sidebar.SidebarOptions.theme')}
 					</MantineMenu.Sub.Item>
 				</MantineMenu.Sub.Target>
 				<MantineMenu.Sub.Dropdown>
@@ -80,7 +82,7 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 			<MantineMenu.Sub position="left">
 				<MantineMenu.Sub.Target>
 					<MantineMenu.Sub.Item leftSection={<IconLanguage size={20} />}>
-						Idioma
+						{t('shared:components.sidebar.SidebarOptions.language')}
 					</MantineMenu.Sub.Item>
 				</MantineMenu.Sub.Target>
 				<MantineMenu.Sub.Dropdown>
@@ -101,19 +103,23 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 				onClick={() => layoutContext.actions.activateFullscreen()}
 				rightSection={layoutContext.data.active_fullscreen ? <IconCheck size={16} /> : null}
 			>
-				{layoutContext.data.active_fullscreen ? 'Sair do Fullscreen' : 'Entrar em Fullscreen'}
+				{layoutContext.data.active_fullscreen
+					? t('shared:components.sidebar.SidebarOptions.exit_fullscreen')
+					: t('shared:components.sidebar.SidebarOptions.enter_fullscreen')}
 			</MantineMenu.Item>
 
 			<MantineMenu.Divider />
 
-			<MantineMenu.Label>Conta</MantineMenu.Label>
+			<MantineMenu.Label>{t('shared:components.sidebar.SidebarOptions.account')}</MantineMenu.Label>
 
 			<MantineMenu.Item
 				leftSection={<IconBellRinging size={20} />}
 				onClick={notificationsContext.actions.requestNotificationPermission}
 				rightSection={notificationsContext.flags.enabled ? <IconCheck size={16} /> : null}
 			>
-				{notificationsContext.flags.enabled ? 'Notificações Ativadas' : 'Ativar Notificações'}
+				{notificationsContext.flags.enabled
+					? t('shared:components.sidebar.SidebarOptions.notifications_enabled')
+					: t('shared:components.sidebar.SidebarOptions.enable_notifications')}
 			</MantineMenu.Item>
 
 			<MantineMenu.Item
@@ -121,12 +127,12 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 				leftSection={<IconLogout size={20} />}
 				onClick={meContext.actions.logout}
 			>
-				Logout
+				{t('shared:components.sidebar.SidebarOptions.logout')}
 			</MantineMenu.Item>
 
 			<MantineMenu.Divider />
 
-			<MantineMenu.Label>Versão {versionContext.data.version}</MantineMenu.Label>
+			<MantineMenu.Label>{t('shared:components.sidebar.SidebarOptions.version', { version: versionContext.data.version })}</MantineMenu.Label>
 
 		</Menu>
 	);

--- a/packages/ui/src/components/sidebar/SidebarOptions/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarOptions/index.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { ColorSwatch, Menu as MantineMenu, type MenuProps } from '@mantine/core';
-import { IconBellRinging, IconBrightness, IconCheck, IconColorSwatch, IconLogout, IconMaximize, IconMinimize, IconSettings } from '@tabler/icons-react';
+import { IconBellRinging, IconBrightness, IconCheck, IconColorSwatch, IconLanguage, IconLogout, IconMaximize, IconMinimize, IconSettings } from '@tabler/icons-react';
 
 import { AVAILABLE_MODES, AVAILABLE_THEMES, useLayoutContext } from '../../../contexts/Layout.context';
+import { useLocaleContext } from '../../../contexts/Locale.context';
 import { useMeContext } from '../../../contexts/Me.context';
 import { useNotificationsContext } from '../../../contexts/Notifications.context';
 import { useVersionContext } from '../../../contexts/Version.context';
+import { enabledLocales } from '../../../i18n/locales';
 import { Menu } from '../../menu/Menu';
 
 /* * */
@@ -25,6 +27,7 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 
 	const meContext = useMeContext();
 	const layoutContext = useLayoutContext();
+	const localeContext = useLocaleContext();
 	const versionContext = useVersionContext();
 	const notificationsContext = useNotificationsContext();
 
@@ -69,6 +72,25 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 							leftSection={<ColorSwatch color={item.primary_color} size={16} />}
 							onClick={() => layoutContext.actions.activateTheme(item._id)}
 							rightSection={layoutContext.data.active_theme === item._id ? <IconCheck size={16} /> : null}
+						>
+							{item.name}
+						</MantineMenu.Item>
+					))}
+				</MantineMenu.Sub.Dropdown>
+			</MantineMenu.Sub>
+
+			<MantineMenu.Sub position="left">
+				<MantineMenu.Sub.Target>
+					<MantineMenu.Sub.Item leftSection={<IconLanguage size={20} />}>
+						Idioma
+					</MantineMenu.Sub.Item>
+				</MantineMenu.Sub.Target>
+				<MantineMenu.Sub.Dropdown>
+					{enabledLocales.map(item => (
+						<MantineMenu.Item
+							key={item._id}
+							onClick={() => localeContext.actions.setLocale(item._id)}
+							rightSection={localeContext.data.locale === item._id ? <IconCheck size={16} /> : null}
 						>
 							{item.name}
 						</MantineMenu.Item>

--- a/packages/ui/src/components/sidebar/SidebarOptions/index.tsx
+++ b/packages/ui/src/components/sidebar/SidebarOptions/index.tsx
@@ -4,7 +4,6 @@ import { ColorSwatch, Menu as MantineMenu, type MenuProps } from '@mantine/core'
 import { IconBellRinging, IconBrightness, IconCheck, IconColorSwatch, IconLanguage, IconLogout, IconMaximize, IconMinimize, IconSettings } from '@tabler/icons-react';
 
 import { AVAILABLE_MODES, AVAILABLE_THEMES, useLayoutContext } from '../../../contexts/Layout.context';
-import { useLocaleContext } from '../../../contexts/Locale.context';
 import { useMeContext } from '../../../contexts/Me.context';
 import { useNotificationsContext } from '../../../contexts/Notifications.context';
 import { useVersionContext } from '../../../contexts/Version.context';
@@ -27,7 +26,6 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 
 	const meContext = useMeContext();
 	const layoutContext = useLayoutContext();
-	const localeContext = useLocaleContext();
 	const versionContext = useVersionContext();
 	const notificationsContext = useNotificationsContext();
 
@@ -89,8 +87,8 @@ export function SidebarOptions({ menuPosition }: SidebarOptionsProps = {}) {
 					{enabledLocales.map(item => (
 						<MantineMenu.Item
 							key={item._id}
-							onClick={() => localeContext.actions.setLocale(item._id)}
-							rightSection={localeContext.data.locale === item._id ? <IconCheck size={16} /> : null}
+							onClick={() => layoutContext.actions.activateLocale(item._id)}
+							rightSection={layoutContext.data.active_locale === item._id ? <IconCheck size={16} /> : null}
 						>
 							{item.name}
 						</MantineMenu.Item>

--- a/packages/ui/src/contexts/Layout.context.tsx
+++ b/packages/ui/src/contexts/Layout.context.tsx
@@ -7,8 +7,9 @@ import { createContext, type PropsWithChildren, useCallback, useContext, useEffe
 import { useFullscreenState } from '../hooks/use-fullscreen-state';
 import { useUserOrganization } from '../hooks/use-user-organization';
 import { useUserPreference } from '../hooks/use-user-preference';
-import { DEFAULT_LOCALE_CODE, enabledLocales, getMatchingLocale } from '../i18n/locales';
+import { DEFAULT_LOCALE_CODE, enabledLocales, getBrowserLocale, getMatchingLocale } from '../i18n/locales';
 import { useLocaleContext } from './Locale.context';
+import { useMeContext } from './Me.context';
 
 /* * */
 
@@ -72,15 +73,18 @@ export const LayoutContextProvider = ({ children }: PropsWithChildren) => {
 
 	const systemColorScheme = useColorScheme();
 	const localeContext = useLocaleContext();
+	const meContext = useMeContext();
 
 	const [userOrganization] = useUserOrganization();
 
 	const defaultTheme: ThemeType = userOrganization?.theme && AVAILABLE_THEMES.some(t => t._id === userOrganization.theme) ? userOrganization.theme as ThemeType : 'ocean';
+	const savedLocalePreference = meContext.actions.getPreference<string>('ui', 'active_locale');
+	const defaultLocale = savedLocalePreference ?? getBrowserLocale();
 
 	const [activeFullscreen, setActiveFullscreen] = useFullscreenState();
 	const [activeTheme, setActiveTheme] = useUserPreference<ThemeType>('ui', 'active_theme', defaultTheme);
 	const [activeMode, setActiveMode] = useUserPreference<ModeType>('ui', 'active_mode', 'system');
-	const [activeLocale, setActiveLocale] = useUserPreference<string>('ui', 'active_locale', DEFAULT_LOCALE_CODE);
+	const [activeLocale, setActiveLocale] = useUserPreference<string>('ui', 'active_locale', defaultLocale);
 
 	//
 	// B. Transform data
@@ -119,6 +123,15 @@ export const LayoutContextProvider = ({ children }: PropsWithChildren) => {
 		const resolvedLocale = matchingLocale?._id ?? DEFAULT_LOCALE_CODE;
 		localeContext.actions.setLocale(resolvedLocale);
 	}, [activeLocale, localeContext.actions]);
+
+	useEffect(() => {
+		if (meContext.actions.getPreference<string>('ui', 'active_locale') != null) return;
+
+		const browserLocale = getBrowserLocale();
+		if (activeLocale === browserLocale) return;
+
+		setActiveLocale(browserLocale, { save: false });
+	}, [activeLocale, meContext.actions, meContext.data.user, setActiveLocale]);
 
 	//
 	// C. Handle actions

--- a/packages/ui/src/contexts/Layout.context.tsx
+++ b/packages/ui/src/contexts/Layout.context.tsx
@@ -7,6 +7,8 @@ import { createContext, type PropsWithChildren, useCallback, useContext, useEffe
 import { useFullscreenState } from '../hooks/use-fullscreen-state';
 import { useUserOrganization } from '../hooks/use-user-organization';
 import { useUserPreference } from '../hooks/use-user-preference';
+import { DEFAULT_LOCALE_CODE, enabledLocales, getMatchingLocale } from '../i18n/locales';
+import { useLocaleContext } from './Locale.context';
 
 /* * */
 
@@ -36,11 +38,13 @@ export type ModeType = (typeof AVAILABLE_MODES)[number]['_id'];
 interface LayoutContextState {
 	actions: {
 		activateFullscreen: () => void
+		activateLocale: (localeId: string) => void
 		activateMode: (modeId: ModeType) => void
 		activateTheme: (themeId: ThemeType) => void
 	}
 	data: {
 		active_fullscreen: boolean
+		active_locale: string
 		active_mode: ModeType
 		active_theme: ThemeType
 	}
@@ -67,6 +71,7 @@ export const LayoutContextProvider = ({ children }: PropsWithChildren) => {
 	// A. Setup variables
 
 	const systemColorScheme = useColorScheme();
+	const localeContext = useLocaleContext();
 
 	const [userOrganization] = useUserOrganization();
 
@@ -75,6 +80,7 @@ export const LayoutContextProvider = ({ children }: PropsWithChildren) => {
 	const [activeFullscreen, setActiveFullscreen] = useFullscreenState();
 	const [activeTheme, setActiveTheme] = useUserPreference<ThemeType>('ui', 'active_theme', defaultTheme);
 	const [activeMode, setActiveMode] = useUserPreference<ModeType>('ui', 'active_mode', 'system');
+	const [activeLocale, setActiveLocale] = useUserPreference<string>('ui', 'active_locale', DEFAULT_LOCALE_CODE);
 
 	//
 	// B. Transform data
@@ -108,8 +114,19 @@ export const LayoutContextProvider = ({ children }: PropsWithChildren) => {
 		document.documentElement.setAttribute('data-fullscreen', activeFullscreen ? 'true' : 'false');
 	}, [activeFullscreen]);
 
+	useEffect(() => {
+		const matchingLocale = getMatchingLocale(activeLocale);
+		const resolvedLocale = matchingLocale?._id ?? DEFAULT_LOCALE_CODE;
+		localeContext.actions.setLocale(resolvedLocale);
+	}, [activeLocale, localeContext.actions]);
+
 	//
 	// C. Handle actions
+
+	const activateLocale = useCallback((localeId: string) => {
+		if (!enabledLocales.some(item => item._id === localeId)) return;
+		setActiveLocale(localeId);
+	}, [setActiveLocale]);
 
 	const activateMode = useCallback((modeId: ModeType) => {
 		if (!AVAILABLE_MODES.some(t => t._id === modeId)) return;
@@ -131,15 +148,17 @@ export const LayoutContextProvider = ({ children }: PropsWithChildren) => {
 	const contextValue: LayoutContextState = useMemo(() => ({
 		actions: {
 			activateFullscreen,
+			activateLocale,
 			activateMode,
 			activateTheme,
 		},
 		data: {
 			active_fullscreen: activeFullscreen,
+			active_locale: activeLocale,
 			active_mode: activeMode,
 			active_theme: activeTheme,
 		},
-	}), [activateFullscreen, activateMode, activateTheme, activeFullscreen, activeMode, activeTheme]);
+	}), [activateFullscreen, activateLocale, activateMode, activateTheme, activeFullscreen, activeLocale, activeMode, activeTheme]);
 
 	//
 	// E. Render components

--- a/packages/ui/src/contexts/Locale.context.tsx
+++ b/packages/ui/src/contexts/Locale.context.tsx
@@ -10,6 +10,7 @@ import { registerModuleTranslations } from '../i18n/utils';
 
 export interface LocaleContextProps {
 	i18n?: {
+		es: object
 		pt: object
 	}
 };
@@ -62,8 +63,10 @@ export const LocaleContextProvider = ({ children, i18n }: PropsWithChildren<Loca
 
 	useEffect(() => {
 		if (!i18n) return;
-		for (const [key, value] of Object.entries(i18n.pt)) {
-			registerModuleTranslations(key, { pt: value });
+		for (const [locale, namespaces] of Object.entries(i18n)) {
+			for (const [namespace, value] of Object.entries(namespaces)) {
+				registerModuleTranslations(namespace, { [locale]: value });
+			}
 		}
 	}, [i18n]);
 

--- a/packages/ui/src/contexts/Locale.context.tsx
+++ b/packages/ui/src/contexts/Locale.context.tsx
@@ -46,7 +46,11 @@ export const LocaleContextProvider = ({ children, i18n }: PropsWithChildren<Loca
 	//
 	// A. Setup Variables
 
-	const [locale, setLocaleState] = useState<string>(getBrowserLocale);
+	const [locale, setLocaleState] = useState<string>(DEFAULT_LOCALE_CODE);
+
+	useEffect(() => {
+		setLocaleState(getBrowserLocale());
+	}, []);
 
 	//
 	// B. Transform Data

--- a/packages/ui/src/contexts/Locale.context.tsx
+++ b/packages/ui/src/contexts/Locale.context.tsx
@@ -4,7 +4,7 @@ import '@tmlmobilidade/ui';
 import i18next from 'i18next';
 import { createContext, type PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
-import { DEFAULT_LOCALE_CODE, getMatchingLocale } from '../i18n/locales';
+import { DEFAULT_LOCALE_CODE, getBrowserLocale, getMatchingLocale } from '../i18n/locales';
 import { registerModuleTranslations } from '../i18n/utils';
 
 /* * */
@@ -35,18 +35,6 @@ export function useLocaleContext() {
 		throw new Error('useLocaleContext must be used within a LocaleContextProvider');
 	}
 	return context;
-}
-
-function getBrowserLocale() {
-	if (typeof window === 'undefined') return DEFAULT_LOCALE_CODE;
-
-	const browserLocales = navigator.languages ? navigator.languages : [navigator.language];
-	for (const browserLocale of browserLocales) {
-		const matchingBrowserLocale = getMatchingLocale(browserLocale.split('-')[0]);
-		if (matchingBrowserLocale) return matchingBrowserLocale._id;
-	}
-
-	return DEFAULT_LOCALE_CODE;
 }
 
 /* * */

--- a/packages/ui/src/contexts/Locale.context.tsx
+++ b/packages/ui/src/contexts/Locale.context.tsx
@@ -4,7 +4,7 @@ import '@tmlmobilidade/ui';
 import i18next from 'i18next';
 import { createContext, type PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
-import { DEFAULT_LOCALE_CODE, getMatchingLocale, LOCALE_STORAGE_KEY } from '../i18n/locales';
+import { DEFAULT_LOCALE_CODE, getMatchingLocale } from '../i18n/locales';
 import { registerModuleTranslations } from '../i18n/utils';
 
 /* * */
@@ -37,6 +37,18 @@ export function useLocaleContext() {
 	return context;
 }
 
+function getBrowserLocale() {
+	if (typeof window === 'undefined') return DEFAULT_LOCALE_CODE;
+
+	const browserLocales = navigator.languages ? navigator.languages : [navigator.language];
+	for (const browserLocale of browserLocales) {
+		const matchingBrowserLocale = getMatchingLocale(browserLocale.split('-')[0]);
+		if (matchingBrowserLocale) return matchingBrowserLocale._id;
+	}
+
+	return DEFAULT_LOCALE_CODE;
+}
+
 /* * */
 
 export const LocaleContextProvider = ({ children, i18n }: PropsWithChildren<LocaleContextProps>) => {
@@ -46,34 +58,10 @@ export const LocaleContextProvider = ({ children, i18n }: PropsWithChildren<Loca
 	//
 	// A. Setup Variables
 
-	const [locale, setLocaleState] = useState<string>(DEFAULT_LOCALE_CODE);
+	const [locale, setLocaleState] = useState<string>(getBrowserLocale);
 
 	//
 	// B. Transform Data
-
-	useEffect(() => {
-		if (typeof window === 'undefined') return;
-
-		const storedLocale = localStorage.getItem(LOCALE_STORAGE_KEY);
-		if (storedLocale) {
-			const matchingStoredLocale = getMatchingLocale(storedLocale);
-			if (matchingStoredLocale) {
-				setLocaleState(matchingStoredLocale._id);
-				return;
-			}
-		}
-
-		const browserLocales = navigator.languages ? navigator.languages : [navigator.language];
-		for (const browserLocale of browserLocales) {
-			const matchingBrowserLocale = getMatchingLocale(browserLocale.split('-')[0]);
-			if (matchingBrowserLocale) {
-				setLocaleState(matchingBrowserLocale._id);
-				return;
-			}
-		}
-
-		setLocaleState(DEFAULT_LOCALE_CODE);
-	}, []);
 
 	useEffect(() => {
 		i18next.changeLanguage(locale);
@@ -90,10 +78,7 @@ export const LocaleContextProvider = ({ children, i18n }: PropsWithChildren<Loca
 
 	const setLocale = useCallback((localeCode: string) => {
 		const matchingLocale = getMatchingLocale(localeCode);
-		const resolvedLocale = matchingLocale?._id ?? DEFAULT_LOCALE_CODE;
-
-		setLocaleState(resolvedLocale);
-		localStorage.setItem(LOCALE_STORAGE_KEY, resolvedLocale);
+		setLocaleState(matchingLocale?._id ?? DEFAULT_LOCALE_CODE);
 	}, []);
 
 	//

--- a/packages/ui/src/contexts/Locale.context.tsx
+++ b/packages/ui/src/contexts/Locale.context.tsx
@@ -2,8 +2,9 @@
 
 import '@tmlmobilidade/ui';
 import i18next from 'i18next';
-import { createContext, type PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, type PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
+import { DEFAULT_LOCALE_CODE, getMatchingLocale, LOCALE_STORAGE_KEY } from '../i18n/locales';
 import { registerModuleTranslations } from '../i18n/utils';
 
 /* * */
@@ -45,16 +46,33 @@ export const LocaleContextProvider = ({ children, i18n }: PropsWithChildren<Loca
 	//
 	// A. Setup Variables
 
-	const [locale, setLocale] = useState<string | undefined>(undefined);
+	const [locale, setLocaleState] = useState<string>(DEFAULT_LOCALE_CODE);
 
 	//
 	// B. Transform Data
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
+
+		const storedLocale = localStorage.getItem(LOCALE_STORAGE_KEY);
+		if (storedLocale) {
+			const matchingStoredLocale = getMatchingLocale(storedLocale);
+			if (matchingStoredLocale) {
+				setLocaleState(matchingStoredLocale._id);
+				return;
+			}
+		}
+
 		const browserLocales = navigator.languages ? navigator.languages : [navigator.language];
-		const lang = browserLocales[0] || 'pt';
-		setLocale(lang.split('-')[0]);
+		for (const browserLocale of browserLocales) {
+			const matchingBrowserLocale = getMatchingLocale(browserLocale.split('-')[0]);
+			if (matchingBrowserLocale) {
+				setLocaleState(matchingBrowserLocale._id);
+				return;
+			}
+		}
+
+		setLocaleState(DEFAULT_LOCALE_CODE);
 	}, []);
 
 	useEffect(() => {
@@ -63,12 +81,20 @@ export const LocaleContextProvider = ({ children, i18n }: PropsWithChildren<Loca
 
 	useEffect(() => {
 		if (!i18n) return;
-		for (const [locale, namespaces] of Object.entries(i18n)) {
+		for (const [localeCode, namespaces] of Object.entries(i18n)) {
 			for (const [namespace, value] of Object.entries(namespaces)) {
-				registerModuleTranslations(namespace, { [locale]: value });
+				registerModuleTranslations(namespace, { [localeCode]: value });
 			}
 		}
 	}, [i18n]);
+
+	const setLocale = useCallback((localeCode: string) => {
+		const matchingLocale = getMatchingLocale(localeCode);
+		const resolvedLocale = matchingLocale?._id ?? DEFAULT_LOCALE_CODE;
+
+		setLocaleState(resolvedLocale);
+		localStorage.setItem(LOCALE_STORAGE_KEY, resolvedLocale);
+	}, []);
 
 	//
 	// C. Context value
@@ -80,7 +106,7 @@ export const LocaleContextProvider = ({ children, i18n }: PropsWithChildren<Loca
 		data: {
 			locale,
 		},
-	}), [locale]);
+	}), [locale, setLocale]);
 
 	//
 	// D. Render components

--- a/packages/ui/src/i18n/config.ts
+++ b/packages/ui/src/i18n/config.ts
@@ -4,7 +4,7 @@ import i18next from 'i18next';
 import ICU from 'i18next-icu';
 import { initReactI18next } from 'react-i18next';
 
-import { i18nResourceKeysPtShared } from './resources';
+import { i18nResourceKeysEsShared, i18nResourceKeysPtShared } from './resources';
 
 /* * */
 
@@ -17,6 +17,7 @@ await i18next
 			escapeValue: true,
 		},
 		resources: {
+			es: i18nResourceKeysEsShared,
 			pt: i18nResourceKeysPtShared,
 		},
 	});

--- a/packages/ui/src/i18n/locales.ts
+++ b/packages/ui/src/i18n/locales.ts
@@ -1,7 +1,6 @@
 'use client';
 
 export const DEFAULT_LOCALE_CODE = 'pt';
-export const LOCALE_STORAGE_KEY = 'locale';
 
 /* * */
 

--- a/packages/ui/src/i18n/locales.ts
+++ b/packages/ui/src/i18n/locales.ts
@@ -16,6 +16,11 @@ export const availableLocales: LocaleConfig[] = [
 		alias: ['pt-PT', 'pt_PT', 'pt-BR', 'pt_BR', 'pt-GW', 'pt_GW', 'pt-MZ', 'pt_MZ'],
 		enabled: true,
 	},
+	{
+		_id: 'es',
+		alias: ['es-ES', 'es_ES', 'es-MX', 'es_MX', 'es-AR', 'es_AR'],
+		enabled: true,
+	},
 ];
 
 /* * */

--- a/packages/ui/src/i18n/locales.ts
+++ b/packages/ui/src/i18n/locales.ts
@@ -41,3 +41,15 @@ export function getMatchingLocale(localeCode: string) {
 	if (matchingLocale) return matchingLocale;
 	else return null;
 }
+
+export function getBrowserLocale() {
+	if (typeof window === 'undefined') return DEFAULT_LOCALE_CODE;
+
+	const browserLocales = navigator.languages ? navigator.languages : [navigator.language];
+	for (const browserLocale of browserLocales) {
+		const matchingBrowserLocale = getMatchingLocale(browserLocale.split('-')[0]);
+		if (matchingBrowserLocale) return matchingBrowserLocale._id;
+	}
+
+	return DEFAULT_LOCALE_CODE;
+}

--- a/packages/ui/src/i18n/locales.ts
+++ b/packages/ui/src/i18n/locales.ts
@@ -1,6 +1,7 @@
 'use client';
 
 export const DEFAULT_LOCALE_CODE = 'pt';
+export const LOCALE_STORAGE_KEY = 'locale';
 
 /* * */
 
@@ -8,6 +9,7 @@ export interface LocaleConfig {
 	_id: string
 	alias: string[]
 	enabled: boolean
+	name: string
 }
 
 export const availableLocales: LocaleConfig[] = [
@@ -15,11 +17,13 @@ export const availableLocales: LocaleConfig[] = [
 		_id: 'pt',
 		alias: ['pt-PT', 'pt_PT', 'pt-BR', 'pt_BR', 'pt-GW', 'pt_GW', 'pt-MZ', 'pt_MZ'],
 		enabled: true,
+		name: 'Português',
 	},
 	{
 		_id: 'es',
 		alias: ['es-ES', 'es_ES', 'es-MX', 'es_MX', 'es-AR', 'es_AR'],
 		enabled: true,
+		name: 'Español',
 	},
 ];
 

--- a/packages/ui/src/i18n/namespaces/alerts/es.json
+++ b/packages/ui/src/i18n/namespaces/alerts/es.json
@@ -1,0 +1,128 @@
+{
+	"causes": {
+		"ABUSIVE_PARKING": {
+			"description": "Obstrucciones provocadas por estacionamiento indebido.",
+			"title": "Estacionamiento indebido"
+		},
+		"ACCIDENT": {
+			"description": "Interrupciones de la vía provocadas por accidentes de tráfico.",
+			"title": "Accidente"
+		},
+		"CONSTRUCTION": {
+			"description": "Intervenciones en la vía pública.",
+			"title": "Obras"
+		},
+		"DEMONSTRATION": {
+			"description": "Festivales, protestas o huelgas de terceros.",
+			"title": "Evento / Manifestación"
+		},
+		"DRIVER_ABSENCE": {
+			"description": "La vía está cerrada debido a mantenimiento u otros motivos.",
+			"title": "Ausencia de conductor"
+		},
+		"DRIVER_ISSUE": {
+			"description": "La vía está cerrada debido a mantenimiento u otros motivos.",
+			"title": "Problema con el conductor"
+		},
+		"HIGH_PASSENGER_LOAD": {
+			"description": "Elevado volumen de pasajeros.",
+			"title": "Alta ocupación"
+		},
+		"MEDICAL_EMERGENCY": {
+			"description": "Incidentes con pasajeros o conductores que requieren asistencia médica.",
+			"title": "Emergencia médica"
+		},
+		"NETWORK_UPDATE": {
+			"description": "Cambios en la red de transporte, como modificaciones de itinerario u horarios.",
+			"title": "Actualización de red"
+		},
+		"POLICE_ACTIVITY": {
+			"description": "Operaciones de control u otras actividades policiales que impiden la circulación.",
+			"title": "Actividad policial"
+		},
+		"PUBLIC_DISORDER": {
+			"description": "Conflictos, agresiones u otras alteraciones en el vehículo.",
+			"title": "Altercados"
+		},
+		"ROAD_ISSUE": {
+			"description": "Impedimentos en la vía por caída de árboles, deslizamientos u otros obstáculos.",
+			"title": "Incidente en la vía"
+		},
+		"STRIKE": {
+			"description": "Huelgas propias o de otros operadores de transporte.",
+			"title": "Huelga"
+		},
+		"TECHNICAL_ISSUE": {
+			"description": "Averías mecánicas, fallos en el AVL o indisponibilidad del validador.",
+			"title": "Problema técnico"
+		},
+		"TRAFFIC_JAM": {
+			"description": "Volumen de tráfico rodado anormalmente elevado.",
+			"title": "Tráfico"
+		},
+		"VEHICLE_ISSUE": {
+			"description": "Averías mecánicas o de sistemas a bordo del vehículo.",
+			"title": "Problema con el vehículo"
+		},
+		"WEATHER": {
+			"description": "Tormentas, lluvias intensas que provocan obstrucciones en la vía.",
+			"title": "Condiciones meteorológicas"
+		}
+	},
+	"effects": {
+		"ACCESSIBILITY_ISSUE": {
+			"description": "Los pasajeros con movilidad reducida se ven especialmente afectados.",
+			"title": "Impacto en la accesibilidad"
+		},
+		"ADDITIONAL_SERVICE": {
+			"description": "Desdoblamientos o nuevos horarios.",
+			"title": "Servicio adicional"
+		},
+		"DETOUR": {
+			"description": "Alteración temporal del recorrido habitual.",
+			"title": "Desvío"
+		},
+		"MODIFIED_SERVICE": {
+			"description": "Cambios en el recorrido u horarios.",
+			"title": "Servicio modificado"
+		},
+		"NO_SERVICE": {
+			"description": "El servicio ha sido cancelado.",
+			"title": "Cancelación"
+		},
+		"ON_BOARD_SALE_ISSUE": {
+			"description": "La venta de billetes está indisponible o limitada.",
+			"title": "Venta a bordo condicionada"
+		},
+		"REALTIME_INFO_ISSUE": {
+			"description": "Problema con la información en tiempo real.",
+			"title": "Impacto en la información al público"
+		},
+		"REDUCED_SERVICE": {
+			"description": "El viaje finalizará anticipadamente.",
+			"title": "Acortamiento de recorrido"
+		},
+		"SIGNIFICANT_DELAYS": {
+			"description": "No será posible cumplir el horario previsto.",
+			"title": "Retrasos significativos"
+		},
+		"STOP_MOVED": {
+			"description": "La parada ha sido desplazada temporalmente.",
+			"title": "Parada desplazada"
+		}
+	},
+	"reference_types": {
+		"agency": {
+			"title": "Operador"
+		},
+		"lines": {
+			"title": "Líneas"
+		},
+		"rides": {
+			"title": "Circulaciones"
+		},
+		"stops": {
+			"title": "Paradas"
+		}
+	}
+}

--- a/packages/ui/src/i18n/namespaces/components/es.json
+++ b/packages/ui/src/i18n/namespaces/components/es.json
@@ -1,0 +1,85 @@
+{
+	"buttons": {
+		"DuplicateButton": {
+			"label": "Duplicar",
+			"tooltip": "Crear una copia de este documento"
+		},
+		"SaveButton": {
+			"label": "Guardar",
+			"tooltip": "Guardar cambios"
+		}
+	},
+	"filters": {
+		"FilterTypeList": {
+			"toggle_all": "Seleccionar todo"
+		}
+	},
+	"inputs": {
+		"CoordinatesInput": {
+			"latitude": {
+				"placeholder": "Latitude (-90 to 90)"
+			},
+			"longitude": {
+				"placeholder": "Longitude (-180 to 180)"
+			}
+		},
+		"SearchInput": {
+			"placeholder": "Buscar..."
+		},
+		"Select": {
+			"nothing_found": "No se encontraron resultados"
+		}
+	},
+	"sidebar": {
+		"Sidebar": {
+			"agencies": "Operadores",
+			"alerts": "Alertas",
+			"annotations": "Anotaciones",
+			"calendar": "Calendario",
+			"collapse_sidebar_aria": "Contraer barra lateral",
+			"events": "Eventos y excepciones",
+			"fares": "Tarifas",
+			"gtfs_validations": "Validaciones GTFS",
+			"hide_sidebar_aria": "Contraer barra lateral",
+			"holidays": "Festivos",
+			"home": "Home",
+			"lines": "Líneas",
+			"organizations": "Organizaciones",
+			"performance": "Performance",
+			"pin_sidebar_aria": "Fijar barra lateral",
+			"plans": "Planes",
+			"reference": "Documentación",
+			"resize_rail_aria": "Redimensionar barra lateral",
+			"rides": "Circulaciones",
+			"roles": "Grupos de permisos",
+			"sams": "SAMS",
+			"stops": "Paradas",
+			"typologies": "Tipologías",
+			"unpin_sidebar_aria": "Desfijar barra lateral",
+			"users": "Usuarios",
+			"vehicles": "Vehículos",
+			"year_periods": "Períodos del año",
+			"zones": "Zonas"
+		},
+		"SidebarGroups": {
+			"administration": "Administración",
+			"calendar_management": "Calendario",
+			"fleet_management": "Flota",
+			"network_offer": "Oferta de red",
+			"offer": "Oferta",
+			"operation": "Operación",
+			"overview": "Visión general"
+		}
+	},
+	"tags": {
+		"IdTag": {
+			"copied": "¡Copiado!",
+			"copy": "Haga clic para copiar el ID"
+		}
+	},
+	"topbar": {
+		"Topbar": {
+			"show_sidebar_aria": "Mostrar barra lateral"
+		}
+	}
+}

--- a/packages/ui/src/i18n/namespaces/components/es.json
+++ b/packages/ui/src/i18n/namespaces/components/es.json
@@ -17,10 +17,10 @@
 	"inputs": {
 		"CoordinatesInput": {
 			"latitude": {
-				"placeholder": "Latitude (-90 to 90)"
+				"placeholder": "Latitud (-90 a 90)"
 			},
 			"longitude": {
-				"placeholder": "Longitude (-180 to 180)"
+				"placeholder": "Longitud (-180 a 180)"
 			}
 		},
 		"SearchInput": {

--- a/packages/ui/src/i18n/namespaces/components/es.json
+++ b/packages/ui/src/i18n/namespaces/components/es.json
@@ -61,6 +61,14 @@
 			"year_periods": "Períodos del año",
 			"zones": "Zonas"
 		},
+		"SidebarExports": {
+			"label": "Exportaciones",
+			"no_exports": "Sin exportaciones disponibles",
+			"title": "Exportaciones"
+		},
+		"SidebarExportsItem": {
+			"no_name": "Sin nombre"
+		},
 		"SidebarGroups": {
 			"administration": "Administración",
 			"calendar_management": "Calendario",
@@ -69,6 +77,31 @@
 			"offer": "Oferta",
 			"operation": "Operación",
 			"overview": "Visión general"
+		},
+		"SidebarNotifications": {
+			"label": "Notificaciones",
+			"no_notifications": "Sin notificaciones disponibles",
+			"read": "Leídas",
+			"unread": "No leídas"
+		},
+		"SidebarNotificationsItem": {
+			"mark_as_read_aria": "Marcar como leído",
+			"no_description": "Sin descripción",
+			"no_title": "Sin título"
+		},
+		"SidebarOptions": {
+			"account": "Cuenta",
+			"customisation": "Personalización",
+			"enable_notifications": "Activar notificaciones",
+			"enter_fullscreen": "Entrar en pantalla completa",
+			"exit_fullscreen": "Salir de pantalla completa",
+			"label": "Ajustes",
+			"language": "Idioma",
+			"logout": "Cerrar sesión",
+			"mode": "Modo",
+			"notifications_enabled": "Notificaciones activadas",
+			"theme": "Tema",
+			"version": "Versión {{version}}"
 		}
 	},
 	"tags": {

--- a/packages/ui/src/i18n/namespaces/components/pt.json
+++ b/packages/ui/src/i18n/namespaces/components/pt.json
@@ -61,6 +61,14 @@
 			"year_periods": "Períodos do Ano",
 			"zones": "Zonas"
 		},
+		"SidebarExports": {
+			"label": "Exportações",
+			"no_exports": "Sem exportações disponíveis",
+			"title": "Exportações"
+		},
+		"SidebarExportsItem": {
+			"no_name": "Sem nome"
+		},
 		"SidebarGroups": {
 			"administration": "Administração",
 			"calendar_management": "Calendário",
@@ -69,6 +77,31 @@
 			"offer": "Oferta",
 			"operation": "Operação",
 			"overview": "Visão Geral"
+		},
+		"SidebarNotifications": {
+			"label": "Notificações",
+			"no_notifications": "Sem notificações disponíveis",
+			"read": "Lidas",
+			"unread": "Não Lidas"
+		},
+		"SidebarNotificationsItem": {
+			"mark_as_read_aria": "Marcar como lido",
+			"no_description": "Sem Descrição",
+			"no_title": "Sem titulo"
+		},
+		"SidebarOptions": {
+			"account": "Conta",
+			"customisation": "Personalização",
+			"enable_notifications": "Ativar Notificações",
+			"enter_fullscreen": "Entrar em Fullscreen",
+			"exit_fullscreen": "Sair do Fullscreen",
+			"label": "Definições",
+			"language": "Idioma",
+			"logout": "Logout",
+			"mode": "Modo",
+			"notifications_enabled": "Notificações Ativadas",
+			"theme": "Tema",
+			"version": "Versão {{version}}"
 		}
 	},
 	"tags": {

--- a/packages/ui/src/i18n/namespaces/operations/es.json
+++ b/packages/ui/src/i18n/namespaces/operations/es.json
@@ -1,0 +1,18 @@
+{
+	"operations": {
+		"Archive": "Archivar",
+		"Cancel": "Cancelar",
+		"Continue": "Continuar",
+		"Create": "Crear",
+		"Delete": "Eliminar",
+		"Duplicate": "Duplicar",
+		"Edit": "Editar",
+		"Eliminate": "Eliminar",
+		"Exclude": "Excluir",
+		"Next": "Siguiente",
+		"Publish": "Publicar",
+		"Restore": "Restaurar",
+		"Save": "Guardar",
+		"Update": "Actualizar"
+	}
+}

--- a/packages/ui/src/i18n/namespaces/status/es.json
+++ b/packages/ui/src/i18n/namespaces/status/es.json
@@ -1,0 +1,81 @@
+{
+	"approval_status": {
+		"approved": "Aprobado",
+		"none": "-",
+		"pending": "Pendiente",
+		"rejected": "Rechazado"
+	},
+	"availability_status": {
+		"available": "Disponible",
+		"unavailable": "No disponible",
+		"unknown": "Desconocido"
+	},
+	"condition_status": {
+		"damaged": "Dañado",
+		"missing": "Faltante",
+		"not_applicable": "No aplicable",
+		"ok": "Ok",
+		"unknown": "Desconocido"
+	},
+	"delay_status": {
+		"delayed": "Retrasada",
+		"early": "Adelantada",
+		"none": "(sin valor)",
+		"ontime": "A tiempo"
+	},
+	"lifecycle_status": {
+		"active": "Activo",
+		"draft": "Borrador",
+		"inactive": "Inactivo",
+		"provisional": "Provisional",
+		"seasonal": "Estacional",
+		"voided": "Anulado"
+	},
+	"operational_status": {
+		"ended": "Finalizada",
+		"missed": "No realizada",
+		"running": "En circulación",
+		"scheduled": "Planificada"
+	},
+	"processing_status": {
+		"complete": "Completado",
+		"error": "Error",
+		"processing": "En curso",
+		"skipped": "Omitido",
+		"waiting": "En espera"
+	},
+	"publish_status": {
+		"archived": "Archivado",
+		"draft": "Borrador",
+		"published": "Publicado"
+	},
+	"seen_status": {
+		"gone": "-",
+		"seen": "Adelantado",
+		"unseen": "Retrasado"
+	},
+	"statuses": {
+		"Archived": "Archivado",
+		"Complete": "Válido",
+		"Concluded": "Concluido",
+		"Draft": "Borrador",
+		"Ended": "Ended",
+		"Error": "Inválido",
+		"Fail": "Fail",
+		"Failed": "Error",
+		"Missed": "Missed",
+		"Pass": "Pass",
+		"Processing": "Procesando",
+		"Published": "Publicado",
+		"Running": "Running",
+		"Scheduled": "Scheduled",
+		"Skipped": "Ignorado",
+		"Unknown": "Desconocido",
+		"Waiting": "En espera"
+	},
+	"validity_status": {
+		"invalid": "Inválido",
+		"unknown": "Desconocido",
+		"valid": "Válido"
+	}
+}

--- a/packages/ui/src/i18n/resources.ts
+++ b/packages/ui/src/i18n/resources.ts
@@ -1,8 +1,12 @@
 'use client';
 
+import namespaceAlertsEs from './namespaces/alerts/es.json' with { type: 'json' };
 import namespaceAlertsPt from './namespaces/alerts/pt.json' with { type: 'json' };
+import namespaceComponentsEs from './namespaces/components/es.json' with { type: 'json' };
 import namespaceComponentsPt from './namespaces/components/pt.json' with { type: 'json' };
+import namespaceOperationsEs from './namespaces/operations/es.json' with { type: 'json' };
 import namespaceOperationsPt from './namespaces/operations/pt.json' with { type: 'json' };
+import namespaceStatusEs from './namespaces/status/es.json' with { type: 'json' };
 import namespaceStatusPt from './namespaces/status/pt.json' with { type: 'json' };
 
 /**
@@ -17,5 +21,17 @@ export const i18nResourceKeysPtShared = {
 		components: namespaceComponentsPt,
 		operations: namespaceOperationsPt,
 		status: namespaceStatusPt,
+	},
+} as const;
+
+/**
+ * Resource keys for i18n translations in Spanish.
+ */
+export const i18nResourceKeysEsShared = {
+	shared: {
+		alerts: namespaceAlertsEs,
+		components: namespaceComponentsEs,
+		operations: namespaceOperationsEs,
+		status: namespaceStatusEs,
 	},
 } as const;


### PR DESCRIPTION
## Summary

Add complete Spanish (es) translations for all frontend modules, alongside
existing Portuguese (pt) support. Includes locale switching infrastructure,
sidebar language selection UI, and translation wiring across all apps.

## Changes

### Translations

- **packages/ui** — Spanish resource bundles for shared components: alerts
  (128 keys), components (118 keys), operations (18 keys), status (81 keys)
- **modules/auth** — Full auth UI translated: user management, organizations,
  roles, permissions, login/change-password/reset-password flows (852 keys)
- **modules/controller** — Rides list/filters, ride analysis (15 analysis
  types), ride details, SAMs management, export flows (708 keys)
- **modules/alerts** — Alert creation flow with causes, effects, references
  (40 keys)
- **modules/hub/videowall** — Passenger-facing UI: action bar, alerts,
  lines/stops/vehicles search, map, help (332 keys)

### Infrastructure

- **Locale management** — Refactored `Locale.context.tsx` and
  `Layout.context.tsx` to support multiple active locales, exposing active
  locale state through the layout context
- **Sidebar UI** — Added language selection toggle in sidebar, with
  translated sidebar labels (Exports, Notifications, Options)
- **Resource wiring** — Updated all module `resources.ts` files to aggregate
  and expose Spanish namespaces to i18next
- **Layout registration** — Registered `es` alongside `pt` in all app layout
  files via `BaseProvider`

### Configuration

- Added supported locale definitions for `es` with aliases (es-ES, es_MX,
  es-AR, etc.) in `locales.ts`
- Updated i18next config to load Spanish resource bundles alongside
  Portuguese