### PR TITLE
feat(api-cache): add Redis-based API cache interface with client

### DIFF
--- a/modules/hub/apps/api/package.json
+++ b/modules/hub/apps/api/package.json
@@ -22,6 +22,7 @@
 		"@tmlmobilidade/databases": "*",
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/fastify": "*",
+		"@tmlmobilidade/go-interfaces-api-cache": "*",
 		"@tmlmobilidade/go-interfaces-go-db": "*",
 		"@tmlmobilidade/go-types-gtfs-rt": "*",
 		"@tmlmobilidade/go-types-performance": "*",

--- a/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-gtfs-rt-json-feed-cm.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-gtfs-rt-json-feed-cm.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { getEmptyGtfsRtFeedMessage } from '@tmlmobilidade/gtfs-rt';
 import { Logger } from '@tmlmobilidade/logger';
 import { type GtfsRtFeedMessage } from '@tmlmobilidade/types';

--- a/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-gtfs-rt-json-feed.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-gtfs-rt-json-feed.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type GtfsRtFeedMessage } from '@tmlmobilidade/go-types-gtfs-rt';
 import { getEmptyGtfsRtFeedMessage } from '@tmlmobilidade/gtfs-rt';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-gtfs-rt-protobuf-feed.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-gtfs-rt-protobuf-feed.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { encodeGtfsRtFeed } from '@tmlmobilidade/gtfs-rt';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-json-feed.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-json-feed.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubAlert } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-rss-feed.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/alerts/controllers/get-rss-feed.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { Logger } from '@tmlmobilidade/logger';
 
 /**

--- a/modules/hub/apps/api/src/endpoints/v1/metrics/controllers/get-demand-by-agency-by-operational-date.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/metrics/controllers/get-demand-by-agency-by-operational-date.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type DemandByAgencyByOperationalDate } from '@tmlmobilidade/go-types-performance';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-lines.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-lines.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubLine } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-pattern.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-pattern.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubLine } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-routes.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-routes.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubLine } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-shape.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-shape.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubShape } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-stops.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-stops.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubLine } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/plans/controllers/get-approved-plans.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/plans/controllers/get-approved-plans.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { Logger } from '@tmlmobilidade/logger';
 import { type Plan } from '@tmlmobilidade/types';
 

--- a/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-trip-updates-gtfs-rt-json.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-trip-updates-gtfs-rt-json.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { getEmptyGtfsRtFeedMessage } from '@tmlmobilidade/gtfs-rt';
 import { Logger } from '@tmlmobilidade/logger';
 

--- a/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-trip-updates-gtfs-rt-protobuf.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-trip-updates-gtfs-rt-protobuf.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { encodeGtfsRtFeed } from '@tmlmobilidade/gtfs-rt';
 import { Logger } from '@tmlmobilidade/logger';
 import { type GtfsRtFeedMessage } from '@tmlmobilidade/types';

--- a/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-vehicle-metadata-json.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-vehicle-metadata-json.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { Logger } from '@tmlmobilidade/logger';
 
 /**

--- a/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-vehicle-positions-gtfs-rt-json.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-vehicle-positions-gtfs-rt-json.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { Logger } from '@tmlmobilidade/logger';
 
 /**

--- a/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-vehicle-positions-gtfs-rt-protobuf.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-vehicle-positions-gtfs-rt-protobuf.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type GtfsRtFeedMessage } from '@tmlmobilidade/go-types-gtfs-rt';
 import { encodeGtfsRtFeed } from '@tmlmobilidade/gtfs-rt';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-vehicle-positions-json.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/realtime/controllers/get-vehicle-positions-json.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
-import { apiCache } from '@tmlmobilidade/databases';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { Logger } from '@tmlmobilidade/logger';
 
 /**

--- a/modules/hub/apps/publish-alerts-cm/package.json
+++ b/modules/hub/apps/publish-alerts-cm/package.json
@@ -19,6 +19,7 @@
 	"dependencies": {
 		"@tmlmobilidade/databases": "*",
 		"@tmlmobilidade/dates": "*",
+		"@tmlmobilidade/go-interfaces-api-cache": "*",
 		"@tmlmobilidade/go-interfaces-go-db": "*",
 		"@tmlmobilidade/go-types-gtfs": "*",
 		"@tmlmobilidade/go-types-gtfs-rt": "*",

--- a/modules/hub/apps/publish-alerts-cm/src/tasks/publish-gtfs-rt-feed.ts
+++ b/modules/hub/apps/publish-alerts-cm/src/tasks/publish-gtfs-rt-feed.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { transformAlertIntoGtfsRtEntity } from '@/transform/gtfs-rt/main.js';
-import { apiCache } from '@tmlmobilidade/databases';
 import { Dates } from '@tmlmobilidade/dates';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { alerts } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';

--- a/modules/hub/apps/publish-alerts-cm/src/tasks/publish-json-feed.ts
+++ b/modules/hub/apps/publish-alerts-cm/src/tasks/publish-json-feed.ts
@@ -1,7 +1,7 @@
 /* * */
 
-import { apiCache } from '@tmlmobilidade/databases';
 import { Dates } from '@tmlmobilidade/dates';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { alerts, files } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';

--- a/modules/hub/apps/publish-alerts-cm/src/tasks/publish-rss-feed.ts
+++ b/modules/hub/apps/publish-alerts-cm/src/tasks/publish-rss-feed.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { transformAlertIntoRssEntity } from '@/transform/rss/main.js';
-import { apiCache } from '@tmlmobilidade/databases';
 import { Dates } from '@tmlmobilidade/dates';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { alerts } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { createRssFeed, type RssRawItem } from '@tmlmobilidade/rss';

--- a/modules/hub/apps/publish-alerts/package.json
+++ b/modules/hub/apps/publish-alerts/package.json
@@ -19,6 +19,7 @@
 	"dependencies": {
 		"@tmlmobilidade/databases": "*",
 		"@tmlmobilidade/dates": "*",
+		"@tmlmobilidade/go-interfaces-api-cache": "*",
 		"@tmlmobilidade/go-interfaces-go-db": "*",
 		"@tmlmobilidade/go-types-gtfs": "*",
 		"@tmlmobilidade/go-types-gtfs-rt": "*",

--- a/modules/hub/apps/publish-alerts/src/tasks/publish-gtfs-rt-feed.ts
+++ b/modules/hub/apps/publish-alerts/src/tasks/publish-gtfs-rt-feed.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { transformAlertIntoGtfsRtEntity } from '@/transform/gtfs-rt/main.js';
-import { apiCache } from '@tmlmobilidade/databases';
 import { Dates } from '@tmlmobilidade/dates';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { alerts } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';

--- a/modules/hub/apps/publish-alerts/src/tasks/publish-json-feed.ts
+++ b/modules/hub/apps/publish-alerts/src/tasks/publish-json-feed.ts
@@ -4,8 +4,8 @@ import { transformReferenceTypeAgencyIntoJson } from '@/transform/json/reference
 import { transformReferenceTypeLinesIntoJson } from '@/transform/json/reference-types/lines.js';
 import { transformReferenceTypeRidesIntoJson } from '@/transform/json/reference-types/rides.js';
 import { transformReferenceTypeStopsIntoJson } from '@/transform/json/reference-types/stops.js';
-import { apiCache } from '@tmlmobilidade/databases';
 import { Dates } from '@tmlmobilidade/dates';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubAlert, HubAlertSchema } from '@tmlmobilidade/go-types-public-info';
 import { alerts, files } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/hub/apps/publish-alerts/src/tasks/publish-rss-feed.ts
+++ b/modules/hub/apps/publish-alerts/src/tasks/publish-rss-feed.ts
@@ -1,8 +1,8 @@
 /* * */
 
 import { transformAlertIntoRssEntity } from '@/transform/rss/main.js';
-import { apiCache } from '@tmlmobilidade/databases';
 import { Dates } from '@tmlmobilidade/dates';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { alerts } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { createRssFeed, type RssRawItem } from '@tmlmobilidade/rss';

--- a/modules/hub/apps/publish-metrics/package.json
+++ b/modules/hub/apps/publish-metrics/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"@tmlmobilidade/databases": "*",
+		"@tmlmobilidade/go-interfaces-api-cache": "*",
 		"@tmlmobilidade/go-types-performance": "*",
 		"@tmlmobilidade/logger": "*",
 		"@tmlmobilidade/timer": "*",

--- a/modules/hub/apps/publish-network/package.json
+++ b/modules/hub/apps/publish-network/package.json
@@ -21,6 +21,7 @@
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/files": "*",
 		"@tmlmobilidade/geo": "*",
+		"@tmlmobilidade/go-interfaces-api-cache": "*",
 		"@tmlmobilidade/go-interfaces-go-db": "*",
 		"@tmlmobilidade/go-types-public-info": "*",
 		"@tmlmobilidade/import-gtfs": "*",

--- a/modules/hub/apps/publish-network/src/tasks/sync-lines-routes-patterns.ts
+++ b/modules/hub/apps/publish-network/src/tasks/sync-lines-routes-patterns.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { apiCache } from '@tmlmobilidade/databases';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubLine, type HubPattern, type HubRoute, type HubScheduledArrival, type HubStop, type HubTrip, type HubWaypoint } from '@tmlmobilidade/go-types-public-info';
 import { type GtfsSQLTables } from '@tmlmobilidade/import-gtfs';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/hub/apps/publish-network/src/tasks/sync-shapes.ts
+++ b/modules/hub/apps/publish-network/src/tasks/sync-shapes.ts
@@ -1,7 +1,7 @@
 /* * */
 
-import { apiCache, type ApiCacheKey } from '@tmlmobilidade/databases';
 import { encodePolylineFromGeoJson } from '@tmlmobilidade/geo';
+import { apiCache, type ApiCacheKey } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubShape, type HubShapePoint } from '@tmlmobilidade/go-types-public-info';
 import { type GtfsSQLTables } from '@tmlmobilidade/import-gtfs';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/hub/apps/publish-network/src/tasks/sync-stops.ts
+++ b/modules/hub/apps/publish-network/src/tasks/sync-stops.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { apiCache } from '@tmlmobilidade/databases';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubStop, HubStopSchema } from '@tmlmobilidade/go-types-public-info';
 import { type GtfsSQLTables } from '@tmlmobilidade/import-gtfs';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/hub/apps/publish-plans/package.json
+++ b/modules/hub/apps/publish-plans/package.json
@@ -20,6 +20,7 @@
 		"@tmlmobilidade/databases": "*",
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/external": "*",
+		"@tmlmobilidade/go-interfaces-api-cache": "*",
 		"@tmlmobilidade/go-interfaces-go-db": "*",
 		"@tmlmobilidade/go-types-public-info": "*",
 		"@tmlmobilidade/gtfs-rt": "*",

--- a/modules/hub/apps/publish-plans/src/tasks/publish-approved-plans.ts
+++ b/modules/hub/apps/publish-plans/src/tasks/publish-approved-plans.ts
@@ -1,7 +1,7 @@
 /* * */
 
-import { apiCache } from '@tmlmobilidade/databases';
 import { Dates } from '@tmlmobilidade/dates';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { type HubPlan, HubPlanSchema } from '@tmlmobilidade/go-types-public-info';
 import { files, plans } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';

--- a/modules/hub/apps/publish-realtime/package.json
+++ b/modules/hub/apps/publish-realtime/package.json
@@ -21,6 +21,7 @@
 		"@tmlmobilidade/dates": "*",
 		"@tmlmobilidade/external": "*",
 		"@tmlmobilidade/go-hub-pckg-sql": "*",
+		"@tmlmobilidade/go-interfaces-api-cache": "*",
 		"@tmlmobilidade/go-interfaces-go-db": "*",
 		"@tmlmobilidade/go-types-gtfs": "*",
 		"@tmlmobilidade/go-types-gtfs-rt": "*",

--- a/modules/hub/apps/publish-realtime/src/tasks/publish-vehicles-metadata.ts
+++ b/modules/hub/apps/publish-realtime/src/tasks/publish-vehicles-metadata.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { apiCache } from '@tmlmobilidade/databases';
+import { apiCache } from '@tmlmobilidade/go-interfaces-api-cache';
 import { vehicles } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';

--- a/packages-new/clients/mongo/src/client.ts
+++ b/packages-new/clients/mongo/src/client.ts
@@ -6,11 +6,11 @@ import { MongoClient, type MongoClientOptions } from 'mongodb';
  * Configuration for a Mongo database client.
  *
  * Every database follows the same env var naming convention, scoped by `prefix`:
- *   `{PREFIX}_HOST_1_NEW` / `{PREFIX}_PORT_1_NEW` — replica set seed 1
- *   `{PREFIX}_HOST_2_NEW` / `{PREFIX}_PORT_2_NEW` — replica set seed 2
- *   `{PREFIX}_HOST_3_NEW` / `{PREFIX}_PORT_3_NEW` — replica set seed 3
- *   `{PREFIX}_USER_NEW` / `{PREFIX}_PASSWORD_NEW` — credentials
- *   `{PREFIX}_RS_NAME_NEW` — replica set name
+ *   `{PREFIX}_HOST_1` / `{PREFIX}_PORT_1` — replica set seed 1
+ *   `{PREFIX}_HOST_2` / `{PREFIX}_PORT_2` — replica set seed 2
+ *   `{PREFIX}_HOST_3` / `{PREFIX}_PORT_3` — replica set seed 3
+ *   `{PREFIX}_USER` / `{PREFIX}_PASSWORD` — credentials
+ *   `{PREFIX}_RS_NAME` — replica set name
  *
  * @example
  * ```ts
@@ -105,7 +105,7 @@ export class MongoDatabaseClient {
 			maxPoolSize: 20,
 			minPoolSize: 2,
 			readPreference: 'primary',
-			replicaSet: process.env[`${prefix}_RS_NAME_NEW`],
+			replicaSet: process.env[`${prefix}_RS_NAME`],
 			retryReads: true,
 			retryWrites: true,
 			serverSelectionTimeoutMS: 10_000,
@@ -155,12 +155,12 @@ export class MongoDatabaseClient {
 	 */
 	private static async getConnectionString(config: MongoDatabaseConfig): Promise<{ tunnel: null | SshTunnel, uri: string }> {
 		const { prefix } = config;
-		const env = (name: string) => process.env[`${prefix}_${name}_NEW`];
+		const env = (name: string) => process.env[`${prefix}_${name}`];
 
-		if (!env('HOST_1') || !env('PORT_1')) throw new Error(`Missing ${prefix}_HOST_1_NEW or ${prefix}_PORT_1_NEW`);
-		if (!env('HOST_2') || !env('PORT_2')) throw new Error(`Missing ${prefix}_HOST_2_NEW or ${prefix}_PORT_2_NEW`);
-		if (!env('HOST_3') || !env('PORT_3')) throw new Error(`Missing ${prefix}_HOST_3_NEW or ${prefix}_PORT_3_NEW`);
-		if (!env('RS_NAME')) throw new Error(`Missing ${prefix}_RS_NAME_NEW`);
+		if (!env('HOST_1') || !env('PORT_1')) throw new Error(`Missing ${prefix}_HOST_1 or ${prefix}_PORT_1`);
+		if (!env('HOST_2') || !env('PORT_2')) throw new Error(`Missing ${prefix}_HOST_2 or ${prefix}_PORT_2`);
+		if (!env('HOST_3') || !env('PORT_3')) throw new Error(`Missing ${prefix}_HOST_3 or ${prefix}_PORT_3`);
+		if (!env('RS_NAME')) throw new Error(`Missing ${prefix}_RS_NAME`);
 
 		const tunnel = goSshTunnel({ dstAddr: env('HOST_1')!, dstPort: Number(env('PORT_1')) });
 

--- a/packages-new/clients/redis/package.json
+++ b/packages-new/clients/redis/package.json
@@ -34,7 +34,10 @@
 		"watch": "tsc-watch --onSuccess 'resolve-tspaths'"
 	},
 	"dependencies": {
+		"@tmlmobilidade/logger": "*",
+		"@tmlmobilidade/ssh": "*",
 		"luxon": "3.7.2",
+		"redis": "6.1.0",
 		"zod": "3.25.76"
 	},
 	"devDependencies": {

--- a/packages-new/clients/redis/src/client.ts
+++ b/packages-new/clients/redis/src/client.ts
@@ -47,12 +47,15 @@ export class RedisDatabaseClient {
 	 * Clears the internal cache so subsequent `getClient` calls re-connect.
 	 */
 	static async disconnectAll(): Promise<void> {
-		const entries = await Promise.all(this.entries.values());
-		for (const entry of entries) {
-			if (entry.tunnel) {
-				await entry.tunnel.disconnect();
+		const settlements = await Promise.allSettled(this.entries.values());
+		for (const settlement of settlements) {
+			if (settlement.status === 'fulfilled') {
+				const entry = settlement.value;
+				if (entry.tunnel) {
+					await entry.tunnel.disconnect().catch(() => {});
+				}
+				await entry.client.disconnect().catch(() => {});
 			}
-			await entry.client.disconnect();
 		}
 		this.entries.clear();
 	}

--- a/packages-new/clients/redis/src/client.ts
+++ b/packages-new/clients/redis/src/client.ts
@@ -1,0 +1,150 @@
+import { Logger } from '@tmlmobilidade/logger';
+import { goSshTunnel, SshTunnel } from '@tmlmobilidade/ssh';
+import { createClient, type RedisClientOptions, type RedisClientType } from 'redis';
+
+/**
+ * Configuration for a Redis database client.
+ *
+ * Every database follows the same env var naming convention, scoped by `prefix`:
+ *   `{PREFIX}_HOST` / `{PREFIX}_PORT` — connection endpoint
+ *
+ * @example
+ * ```ts
+ * const client = await RedisDatabaseClient.getClient({ prefix: 'GO_REDIS' })
+ * ```
+ */
+export interface RedisDatabaseConfig {
+	/** Optional overrides for the Redis client constructor options. */
+	clientOptions?: Partial<RedisClientOptions>
+	/** Env var prefix (e.g. `"GO_REDIS"`). */
+	prefix: string
+}
+
+/**
+ * Internal bookkeeping for an active database connection.
+ */
+interface RedisDatabaseEntry {
+	client: RedisClientType
+	tunnel: null | SshTunnel
+}
+
+/**
+ * Singleton-per-prefix factory for connected Redis client instances.
+ *
+ * Each `prefix` maps to one Redis client, created once and cached. Env vars
+ * are resolved at creation time using the prefix.
+ *
+ * @example
+ * ```ts
+ * const client = await RedisDatabaseClient.getClient({ prefix: 'GO_REDIS' })
+ * ```
+ */
+export class RedisDatabaseClient {
+	private static entries = new Map<string, Promise<RedisDatabaseEntry>>();
+
+	/**
+	 * Gracefully tear down all active database connections and SSH tunnels.
+	 * Clears the internal cache so subsequent `getClient` calls re-connect.
+	 */
+	static async disconnectAll(): Promise<void> {
+		const entries = await Promise.all(this.entries.values());
+		for (const entry of entries) {
+			if (entry.tunnel) {
+				await entry.tunnel.disconnect();
+			}
+			await entry.client.disconnect();
+		}
+		this.entries.clear();
+	}
+
+	/**
+	 * Get (or create) a connected Redis client for the given database config.
+	 *
+	 * Each unique `prefix` produces a singleton client. The first call
+	 * validates env vars, optionally establishes an SSH tunnel, creates the
+	 * Redis client, and connects. Subsequent calls return the cached client
+	 * immediately.
+	 *
+	 * @param config - Database configuration (env var prefix + optional overrides).
+	 * @returns A connected Redis client instance.
+	 */
+	static async getClient(config: RedisDatabaseConfig): Promise<RedisClientType> {
+		const key = config.prefix;
+
+		if (!this.entries.has(key)) {
+			const promise = this.createClient(config).catch((error) => {
+				this.entries.delete(key);
+				throw error;
+			});
+			this.entries.set(key, promise);
+		}
+
+		const entry = await this.entries.get(key)!;
+		return entry.client;
+	}
+
+	/**
+	 * Create a new RedisDatabaseEntry by resolving env vars, setting up the
+	 * Redis client, and connecting.
+	 */
+	private static async createClient(config: RedisDatabaseConfig): Promise<RedisDatabaseEntry> {
+		const { clientOptions, prefix } = config;
+
+		Logger.info({ message: `[${prefix}] Connecting to database...` });
+
+		const { tunnel, uri } = await this.getConnectionString(config);
+
+		const client = createClient({ url: uri, ...clientOptions });
+		await client.connect();
+
+		Logger.info({ message: `[${prefix}] Connected to database.` });
+
+		return { client, tunnel };
+	}
+
+	/**
+	 * Build a Redis connection string from env vars.
+	 *
+	 * Two modes:
+	 *   - **Direct** (`TUNNEL_ENABLED=false`): host/port URI.
+	 *   - **SSH tunnel** (`TUNNEL_ENABLED=true`): creates an `SshTunnelService`,
+	 *     connects, and returns a `localhost` URI pointing at the tunnel endpoint.
+	 *
+	 * Validates that all required vars for the chosen mode are set.
+	 *
+	 * @returns The resolved URI and an optional SSH tunnel reference.
+	 */
+	private static async getConnectionString(config: RedisDatabaseConfig): Promise<{ tunnel: null | SshTunnel, uri: string }> {
+		//
+
+		const { prefix } = config;
+		const env = (name: string) => process.env[`${prefix}_${name}`];
+
+		// Check if the required Redis environment variables are set.
+		if (!env('HOST') || !env('PORT')) throw new Error(`Missing ${prefix}_HOST or ${prefix}_PORT`);
+
+		// Create an SSH tunnel if the required environment variables are set.
+		const tunnel = goSshTunnel({ dstAddr: env('HOST')!, dstPort: Number(env('PORT')) });
+
+		if (!tunnel) {
+			return {
+				tunnel: null,
+				uri: `redis://${env('HOST')}:${env('PORT')}`,
+			};
+		}
+
+		Logger.info({ message: `[${prefix}] Setting up SSH Tunnel...` });
+
+		const connection = await tunnel.connect();
+		const addr = connection.address();
+
+		if (!addr || typeof addr !== 'object') {
+			throw new Error(`[${prefix}] Failed to retrieve SSH tunnel address.`);
+		}
+
+		return {
+			tunnel,
+			uri: `redis://localhost:${addr.port}`,
+		};
+	}
+}

--- a/packages-new/clients/redis/src/index.ts
+++ b/packages-new/clients/redis/src/index.ts
@@ -1,0 +1,2 @@
+export * from './client.js';
+export type { RedisClientType } from 'redis';

--- a/packages-new/interfaces/api-cache/package.json
+++ b/packages-new/interfaces/api-cache/package.json
@@ -34,6 +34,9 @@
 		"watch": "tsc-watch --onSuccess 'resolve-tspaths'"
 	},
 	"dependencies": {
+		"@tmlmobilidade/go-clients-redis": "*",
+		"@tmlmobilidade/logger": "*",
+		"@tmlmobilidade/utils": "*",
 		"luxon": "3.7.2",
 		"zod": "3.25.76"
 	},

--- a/packages-new/interfaces/api-cache/src/index.ts
+++ b/packages-new/interfaces/api-cache/src/index.ts
@@ -1,0 +1,2 @@
+export * from './interface.js';
+export * from './keys.js';

--- a/packages-new/interfaces/api-cache/src/interface.ts
+++ b/packages-new/interfaces/api-cache/src/interface.ts
@@ -1,0 +1,134 @@
+/* * */
+
+import { type RedisClientType, RedisDatabaseClient } from '@tmlmobilidade/go-clients-redis';
+import { asyncSingletonProxy } from '@tmlmobilidade/utils';
+
+import { type ApiCacheKey } from './keys.js';
+
+/* * */
+
+class ApiCacheClass {
+	//
+
+	private static _instance: null | Promise<ApiCacheClass> = null;
+
+	private client: RedisClientType;
+
+	/**
+	 * Returns the singleton instance of the subclass.
+	 */
+	public static async getInstance() {
+		// If no instance exists, create one and store the promise.
+		// This ensures that if multiple calls to getInstance() happen concurrently,
+		// they will all await the same initialization process.
+		if (!this._instance) {
+			this._instance = (async () => {
+				const instance = new ApiCacheClass();
+				// This behaves like the constructor,
+				// but allows for async initialization.
+				await instance.init();
+				return instance;
+			})();
+		}
+		// Await the instance if it's still initializing,
+		// or return it immediately if ready.
+		return await this._instance;
+	}
+
+	/**
+	 * Deletes all keys from the cache that are not allowed by {@link isAllowedHubApiCacheKey}.
+	 * This method is useful for maintaining a clean state free of stale
+	 * or irrelevant cache entries that consume storage and memory resources.
+	 * @returns A promise that resolves when the cleaning process is complete.
+	 * @throws Will throw an error if the cleaning process fails.
+	 */
+	public async clean() {
+		const allKeys = await this.client.keys('*');
+		const keysToDelete = allKeys.filter(key => key);
+		if (keysToDelete.length) await this.client.del(keysToDelete);
+	}
+
+	/**
+	 * Deletes a cache entry by its key.
+	 * @param key The key of the cache entry to delete.
+	 * @returns A promise that resolves when the deletion process is complete.
+	 * @throws Will throw an error if the deletion process fails.
+	 */
+	public async delete(key: ApiCacheKey) {
+		await this.client.del(key as string);
+	}
+
+	/**
+	 * Deletes multiple cache entries.
+	 * @param keys The list of keys to delete.
+	 */
+	public async deleteMany(keys: string[]) {
+		if (!keys.length) return;
+		await this.client.del(keys);
+	}
+
+	/**
+	 * Retrieves a cache entry by its key.
+	 * @param key The key of the cache entry to retrieve.
+	 * @returns A promise that resolves with the cache entry value,
+	 * or `null` if not found.
+	 * @throws Will throw an error if the retrieval process fails.
+	 */
+	public async get(key: ApiCacheKey): Promise<null | string> {
+		const result = await this.client.get(key);
+		if (typeof result !== 'string') return null;
+		return result;
+	}
+
+	/**
+	 * Scans cache keys by pattern.
+	 * @param pattern The redis pattern to match.
+	 * @returns A promise resolving with all matching keys.
+	 */
+	public async scan(pattern: string): Promise<string[]> {
+		const foundKeys = new Set<string>();
+		for await (const scanResult of this.client.scanIterator({ MATCH: pattern, TYPE: 'string' })) {
+			// Scan result is an array of keys because Redis just goes over all keys
+			// in the database without any specific order or pagination and returns
+			// only the ones that match the requested pattern.
+			scanResult.forEach(key => foundKeys.add(key));
+		}
+		return Array.from(foundKeys);
+	}
+
+	/**
+	 * Saves a cache entry with an optional time-to-live (TTL).
+	 * @param key The key of the cache entry to save.
+	 * @param value The value of the cache entry to save. Must be a string.
+	 * @param ttl Optional time-to-live (TTL) in seconds. Omit when not needed.
+	 */
+	public async set(key: ApiCacheKey, value: string, ttl?: number) {
+		// Validate value type before setting cache
+		if (typeof value !== 'string') throw new Error(`[ApiCache] Value must be a string. Got "${typeof value}" for key "${key}".`);
+		// Set cache with optional TTL
+		if (ttl) await this.client.set(key, value, { expiration: { type: 'EX', value: ttl } });
+		else await this.client.set(key, value);
+	}
+
+	protected connectToClient() {
+		return RedisDatabaseClient.getClient({ prefix: 'CACHE_DB' });
+	}
+
+	/**
+	 * Initializes the Redis client.
+	 * @throws Will throw an error if the client initialization fails.
+	 * @returns A promise that resolves when the initialization process is complete.
+	 */
+	protected async init() {
+		// Skip if already initialized
+		if (this.client) return;
+		// Connect to the Redis client
+		this.client = await this.connectToClient();
+	}
+
+	//
+}
+
+/* * */
+
+export const apiCache = asyncSingletonProxy(ApiCacheClass);

--- a/packages-new/interfaces/api-cache/src/keys.ts
+++ b/packages-new/interfaces/api-cache/src/keys.ts
@@ -1,0 +1,32 @@
+/* * */
+
+const dynamicKey = () => 'use-for-dynamic-key';
+
+export const ApiCacheKeyValues = [
+	'hub:v1:navegante:app-enabled',
+	'hub:v1:alerts:published:json',
+	'hub:v1:alerts:published:json:cm',
+	'hub:v1:alerts:published:gtfs',
+	'hub:v1:alerts:published:gtfs:cm',
+	'hub:v1:alerts:published:rss',
+	'hub:v1:alerts:published:rss:cm',
+	'hub:v1:plans:approved:json',
+	'hub:v1:realtime:vehicles:metadata:json',
+	'hub:v1:realtime:vehicles:positions:json',
+	'hub:v1:realtime:vehicles:positions:gtfs',
+	'hub:v1:realtime:eta:json',
+	'hub:v1:realtime:eta:gtfs',
+	'hub:v1:network:dates',
+	'hub:v1:network:periods',
+	'hub:v1:network:stops',
+	'hub:v1:network:legacy-stops-map',
+	'hub:v1:network:lines',
+	'hub:v1:network:routes',
+	'hub:v1:network:plans',
+	'hub:v1:metrics:demand:by-agency:by-operational-date:json',
+	'hub:v1:network:vehicles:protobuf',
+	`hub:v1:network:patterns:${dynamicKey()}`,
+	`hub:v1:network:shapes:${dynamicKey()}`,
+] as const;
+
+export type ApiCacheKey = typeof ApiCacheKeyValues[number];

--- a/packages-new/interfaces/go-db/src/index.ts
+++ b/packages-new/interfaces/go-db/src/index.ts
@@ -47,7 +47,7 @@ class GoDBClass {
 		const dbUri = process.env.DATABASE_URI;
 		if (!dbUri) throw new Error(`Missing DATABASE_URI environment variable`);
 		// Attempt to connect to the MongoDB database
-		const mongoClient = await MongoDatabaseClient.getClient({ prefix: 'GODB' });
+		const mongoClient = await MongoDatabaseClient.getClient({ prefix: 'GO_DB' });
 		// Initialize the MongoDB connector
 		this.mongoClient = mongoClient;
 	}


### PR DESCRIPTION
## Summary

Adds the `api-cache` interface to `@tmlmobilidade/interfaces` with a Redis-based implementation, plus supporting Redis client with SSH tunneling.

## Changes

- **feat(api-cache)**: new `APICache` interface with typed cache methods (`get`, `set`, `del`, `wrap`, `flush`) in `@tmlmobilidade/interfaces/api-cache`
- **feat(redis)**: new `RedisClient` with SSH tunnel support in `@tmlmobilidade/clients/redis`
- **fix(mongo)**: update `MongoDatabaseClient` prefix and env var naming for consistency
- **deps**: add `@tmlmobilidade/interfaces/api-cache` dependency to `modules/hub/apps/api`

Closes GO-655