### PR TITLE
feat(raw-db): add raw database interface package

### DIFF
--- a/packages-new/clients/mongo/src/index.ts
+++ b/packages-new/clients/mongo/src/index.ts
@@ -5,7 +5,9 @@ export * from './client.js';
 export type {
 	AggregateOptions,
 	AggregationCursor,
+	AnyBulkWriteOperation,
 	BulkWriteOptions,
+	BulkWriteResult,
 	ChangeStreamDeleteDocument,
 	ChangeStreamDocument,
 	ChangeStreamInsertDocument,

--- a/packages-new/interfaces/raw-db/package.json
+++ b/packages-new/interfaces/raw-db/package.json
@@ -1,0 +1,58 @@
+{
+	"name": "@tmlmobilidade/go-interfaces-raw-db",
+	"version": "1.0.0",
+	"author": {
+		"email": "iso@tmlmobilidade.pt",
+		"name": "TML-ISO"
+	},
+	"license": "AGPL-3.0-or-later",
+	"homepage": "https://go.tmlmobilidade.pt",
+	"bugs": {
+		"url": "https://github.com/tmlmobilidade/go/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tmlmobilidade/go.git"
+	},
+	"keywords": [
+		"public transit",
+		"tml",
+		"transportes metropolitanos de lisboa",
+		"go"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"type": "module",
+	"files": ["dist"],
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "tsc && resolve-tspaths",
+		"lint": "eslint ./src/ && tsc --noEmit",
+		"lint:fix": "eslint ./src/ --fix",
+		"watch": "tsc-watch --onSuccess 'resolve-tspaths'"
+	},
+	"dependencies": {
+		"@tmlmobilidade/consts": "*",
+		"@tmlmobilidade/dates": "*",
+		"@tmlmobilidade/go-clients-mongo": "*",
+		"@tmlmobilidade/go-types-apex": "*",
+		"@tmlmobilidade/go-types-shared": "*",
+		"@tmlmobilidade/logger": "*",
+		"@tmlmobilidade/strings": "*",
+		"@tmlmobilidade/types": "*",
+		"@tmlmobilidade/utils": "*",
+		"bcryptjs": "3.0.3",
+		"luxon": "3.7.2",
+		"zod": "3.25.76"
+	},
+	"devDependencies": {
+		"@tmlmobilidade/tsconfig": "*",
+		"@types/luxon": "3.7.2",
+		"@types/node": "26.1.0",
+		"resolve-tspaths": "0.8.23",
+		"tsc-watch": "7.2.1",
+		"typescript": "6.0.3"
+	}
+}

--- a/packages-new/interfaces/raw-db/src/databases/raw.ts
+++ b/packages-new/interfaces/raw-db/src/databases/raw.ts
@@ -1,0 +1,32 @@
+/* * */
+
+import type { Db, MongoClient } from '@tmlmobilidade/go-clients-mongo';
+import type { RawVehicleEvent } from '@tmlmobilidade/types';
+
+import { MongoInterfaceTemplate } from '@/interface.template.js';
+import { RawApexTransaction, RawApexTransactionSchema } from '@tmlmobilidade/go-types-apex';
+import { RawVehicleEventSchema } from '@tmlmobilidade/types';
+
+/* * */
+
+export class RawDatabase {
+	//
+
+	//
+	// Collections
+	public readonly rawApexTransactions: MongoInterfaceTemplate<RawApexTransaction, RawApexTransaction>;
+	public readonly rawVehicleEvents: MongoInterfaceTemplate<RawVehicleEvent, RawVehicleEvent>;
+
+	//
+	private readonly database: Db;
+	private readonly databaseName = 'raw';
+
+	public constructor(instance: MongoClient) {
+		// Create the database instance
+		this.database = instance.db(this.databaseName);
+
+		// Create collection interfaces
+		this.rawApexTransactions = new MongoInterfaceTemplate<RawApexTransaction, RawApexTransaction>('raw_apex_transactions', this.database, RawApexTransactionSchema);
+		this.rawVehicleEvents = new MongoInterfaceTemplate<RawVehicleEvent, RawVehicleEvent>('raw_vehicle_events', this.database, RawVehicleEventSchema);
+	}
+}

--- a/packages-new/interfaces/raw-db/src/index.ts
+++ b/packages-new/interfaces/raw-db/src/index.ts
@@ -1,0 +1,54 @@
+/* * */
+
+import { type MongoClient, MongoDatabaseClient } from '@tmlmobilidade/go-clients-mongo';
+import { asyncSingletonProxy } from '@tmlmobilidade/utils';
+
+import { RawDatabase } from './databases/raw.js';
+
+/* * */
+
+class RawDBClass {
+	//
+
+	//
+	//
+	private static _instance: RawDBClass;
+
+	private mongoClient: MongoClient;
+
+	//
+	// Databases
+	public readonly raw: RawDatabase;
+
+	/**
+	 * Establishes a connection to the Mongo database and initializes the collection.
+	 * @param options Optional Mongo client connection options.
+	 * @throws Error if the environment variable for the database URI is missing or if the connection fails.
+	 */
+	public static async getInstance() {
+		if (!RawDBClass._instance) {
+			const instance = new RawDBClass();
+			await instance.connect();
+			RawDBClass._instance = instance;
+		}
+		return RawDBClass._instance;
+	}
+
+	private async connect() {
+		// Extract the database URI from environment variables
+		const dbUri = process.env.DATABASE_URI;
+		if (!dbUri) throw new Error(`Missing DATABASE_URI environment variable`);
+		// Attempt to connect to the MonRawDB database
+		const mongoClient = await MongoDatabaseClient.getClient({ prefix: 'RAW_DB' });
+		// Initialize the MonRawDB connector
+		this.mongoClient = mongoClient;
+	}
+
+	//
+	// Constructor
+	private constructor() {
+		this.raw = new RawDatabase(this.mongoClient);
+	}
+}
+
+export const RawDb = asyncSingletonProxy(RawDBClass);

--- a/packages-new/interfaces/raw-db/src/index.ts
+++ b/packages-new/interfaces/raw-db/src/index.ts
@@ -35,9 +35,6 @@ class RawDBClass {
 	}
 
 	private async connect() {
-		// Extract the database URI from environment variables
-		const dbUri = process.env.DATABASE_URI;
-		if (!dbUri) throw new Error(`Missing DATABASE_URI environment variable`);
 		// Attempt to connect to the MonRawDB database
 		const mongoClient = await MongoDatabaseClient.getClient({ prefix: 'RAW_DB' });
 		// Initialize the MonRawDB connector

--- a/packages-new/interfaces/raw-db/src/index.ts
+++ b/packages-new/interfaces/raw-db/src/index.ts
@@ -14,7 +14,7 @@ class RawDBClass {
 	//
 	private static _instance: RawDBClass;
 
-	private mongoClient: MongoClient;
+	private readonly mongoClient: MongoClient;
 
 	//
 	// Databases
@@ -22,28 +22,20 @@ class RawDBClass {
 
 	/**
 	 * Establishes a connection to the Mongo database and initializes the collection.
-	 * @param options Optional Mongo client connection options.
-	 * @throws Error if the environment variable for the database URI is missing or if the connection fails.
+	 * @throws Error if required RAW_DB_* environment variables are missing or if the connection fails.
 	 */
 	public static async getInstance() {
 		if (!RawDBClass._instance) {
-			const instance = new RawDBClass();
-			await instance.connect();
-			RawDBClass._instance = instance;
+			const mongoClient = await MongoDatabaseClient.getClient({ prefix: 'RAW_DB' });
+			RawDBClass._instance = new RawDBClass(mongoClient);
 		}
 		return RawDBClass._instance;
 	}
 
-	private async connect() {
-		// Attempt to connect to the MonRawDB database
-		const mongoClient = await MongoDatabaseClient.getClient({ prefix: 'RAW_DB' });
-		// Initialize the MonRawDB connector
-		this.mongoClient = mongoClient;
-	}
-
 	//
 	// Constructor
-	private constructor() {
+	private constructor(mongoClient: MongoClient) {
+		this.mongoClient = mongoClient;
 		this.raw = new RawDatabase(this.mongoClient);
 	}
 }

--- a/packages-new/interfaces/raw-db/src/interface.template.ts
+++ b/packages-new/interfaces/raw-db/src/interface.template.ts
@@ -1,0 +1,208 @@
+/* * */
+
+import { type SimplifiedMongoIndex } from '@/types/mongo/index-description.js';
+import { isSameIndex, prepareMongoIndexOptions } from '@/utils/mongo/index.js';
+import { AnyBulkWriteOperation, BulkWriteOptions, BulkWriteResult, Collection, CreateIndexesOptions, Db, Filter, FindOptions, InsertOneOptions, WithId } from '@tmlmobilidade/go-clients-mongo';
+import { Logger } from '@tmlmobilidade/logger';
+import { z } from 'zod';
+
+/* * */
+
+export class MongoInterfaceTemplate<T extends Document, TCreate> {
+	//
+
+	private readonly collectionName: string;
+	private readonly createSchema: z.ZodSchema;
+	private readonly database: Db;
+	private readonly indexDescription: false | SimplifiedMongoIndex<T>[];
+
+	//
+	private readonly collection: Collection<T>;
+
+	/**
+	 * @param collectionName - The name of the collection to create the interface for.
+	 * @param database - The database to create the interface for.
+	 * @param createSchema - The schema to use for creating documents.
+	 * @param indexDescription - The index description to use for the collection.
+	 */
+	public constructor(collectionName: string, database: Db, createSchema: z.ZodSchema, indexDescription: false | SimplifiedMongoIndex<T>[] = []) {
+		this.collection = database.collection<T>(collectionName);
+		this.database = database;
+		this.createSchema = createSchema;
+		this.indexDescription = indexDescription;
+	}
+
+	/**
+	 * Counts documents matching the filter criteria.
+	 * @param filter The filter criteria to match documents.
+	 * @returns A promise that resolves to the count of matching documents.
+	 */
+	public async count(filter?: Filter<T>): Promise<number> {
+		return await this.collection.countDocuments(filter);
+	}
+
+	/**
+	 * Finds all distinct values for a key in the collection.
+	 * @param key The key to find distinct values for.
+	 * @param filter Optional filter criteria to match documents before extracting distinct values.
+	 * @returns A promise that resolves to an array of distinct values for the given key.
+	 */
+	public async distinct<Key extends keyof WithId<T>>(key: Key, filter: Filter<T>) {
+		return this.collection.distinct(key, filter);
+	}
+
+	/**
+	 * Finds multiple documents matching the filter criteria,
+	 * with optional pagination and sorting.
+	 * @param filter (Optional) filter criteria to match documents.
+	 * @param options (Optional) find options.
+	 * @returns A promise that resolves to an array of matching documents.
+	 */
+	public async findMany(filter: Filter<T>, options?: FindOptions) {
+		return await this.collection.find(filter, options).toArray();
+	}
+
+	/**
+	 * Finds a single document matching the filter criteria.
+	 * @param filter The filter criteria to match the document.
+	 * @param options Optional options.
+	 * @returns A promise that resolves to the matching document or null if not found.
+	 */
+	public async findOne(filter: Filter<T>, options?: FindOptions) {
+		return await this.collection.findOne(filter, options);
+	}
+
+	/**
+	 * Provides access to the MongoDB collection instance,
+	 * initializing it if it has not already been created.
+	 * @returns A promise that resolves to the MongoDB collection instance.
+	 * @warning Use with caution: direct access to the collection allows for executing arbitrary queries.
+	 */
+	public async getCollection(): Promise<Collection<T>> {
+		if (!this.collection) await this.init();
+		return this.collection;
+	}
+
+	/**
+	 * This method allows for performing multiple write operations
+	 * in a single request, which can improve performance.
+	 * The operations can include inserts, updates, deletes, and replacements.
+	 * @param operations An array of bulk write operations to execute on the collection.
+	 * @param options The options for the bulk write operation.
+	 * @returns A promise that resolves to the result of the bulk write operation.
+	 * @warning This method does not perform schema validation on the operations.
+	 * It is the responsibility of the caller to ensure that the operations are valid and conform to the expected schemas.
+	 */
+	public async bulkWrite(operations: AnyBulkWriteOperation<T>[], options?: BulkWriteOptions): Promise<BulkWriteResult> {
+		return await this.collection.bulkWrite(operations, options);
+	}
+
+	/**
+	 * Inserts multiple documents into the collection after validating them against the create schema.
+	 * @param data An array of documents to insert, conforming to the TCreate type.
+	 * @param options Optional insert options to configure the behavior of the insert operation.
+	 * @returns A promise that resolves to the result of the insertMany operation.
+	 */
+	public async insertMany(data: TCreate[], options?: InsertOneOptions) {
+		// If no create schema is defined, throw an error.
+		if (!this.createSchema) throw new Error(`No schema defined for insert operation for ${this.collectionName} collection.`);
+		// Validate each document against the create schema
+		const parsedDocuments = data.map((doc) => {
+			const parseResult = this.createSchema.safeParse(doc);
+			if (!parseResult.success) throw new Error(`Document validation failed: ${parseResult.error.message}`);
+			return parseResult.data;
+		});
+		// Attempt to insert the documents into the collection
+		return await this.collection.insertMany(parsedDocuments, options);
+	}
+
+	public async insertOne(data: TCreate, options?: InsertOneOptions) {
+		// If no create schema is defined, throw an error.
+		if (!this.createSchema) throw new Error(`No schema defined for insert operation for ${this.collectionName} collection.`);
+		// Validate the document against the create schema
+		const parseResult = this.createSchema.safeParse(data);
+		if (!parseResult.success) throw new Error(`Document validation failed: ${parseResult.error.message}`);
+		// Attempt to insert the document into the collection
+		return await this.collection.insertOne(parseResult.data, options);
+	}
+
+	/**
+	 * Initializes the MongoDB client and ensures that the specified database and collection exist.
+	 * This method should be called before performing any operations on the database or collection.
+	 * It handles the asynchronous setup process and logs any errors that occur during initialization.
+	 * @throws Will throw an error if the client initialization or database/collection setup fails.
+	 * @returns A promise that resolves when the initialization process is complete.
+	 */
+	protected async init() {
+		// Ensure the collection exists and its indexes are in sync
+		// with the provided index description.
+		await this.createCollectionIfNotExists();
+		await this.syncIndexes();
+		// Call postInit for any additional setup logic defined in subclasses
+		await this.postInit();
+	}
+
+	/**
+	 * Optional override for custom setup logic:
+	 * indexes, materialized views, constraints, etc.
+	 */
+	protected async postInit(): Promise<void> {
+		// no-op by default
+	}
+
+	/**
+	 * Ensures that the specified collection exists in the MongoDB database,
+	 * creating it if it does not already exist.
+	 * @returns A promise that resolves when the collection is ensured to exist.
+	 */
+	private async createCollectionIfNotExists(): Promise<void> {
+		const collections = await this.database.listCollections({ name: this.collectionName }).toArray();
+		if (collections.length) return;
+		await this.database.createCollection(this.collectionName);
+		Logger.info({ message: `MONGODB [${this.collectionName}]: Collection created.` });
+	}
+
+	/**
+	 * Ensures that the specified indexes exist in MongoDB, creating them if they do not already exist.
+	 * This method performs input validation to prevent unsafe operations and logs the outcome of the operation.
+	 * It constructs the necessary index creation queries based on the provided index descriptions and executes them using the client.
+	 * @throws Will throw an error if any of the inputs are unsafe or if the index creation query fails.
+	 * @returns A promise that resolves when the indexes are ensured to exist.
+	 */
+	private async syncIndexes(): Promise<void> {
+		try {
+			if (this.indexDescription === false) {
+				Logger.info({ message: `MONGODB [${this.collectionName}]: Skipping index synchronization.` });
+				return;
+			}
+			// Start index synchronization process
+			Logger.info({ message: `MONGODB [${this.collectionName}]: Synchronizing indexes...` });
+			// Normalize already applied and new indexes
+			// and filter the default _id index.
+			const existingIndexes = await this.collection.indexes();
+			const filteredExisting = existingIndexes.filter(idx => JSON.stringify(idx.key) !== JSON.stringify({ _id: 1 }));
+			// Setup desired indexes based on indexDescription
+			const indexesToCreate: SimplifiedMongoIndex<T>[] = [];
+			// Find indexes to create
+			for (const desiredIdx of this.indexDescription) {
+				// For the list of desired indexes,
+				// check if they are present in the existing indexes.
+				const found = filteredExisting.some(existingIdx => isSameIndex(existingIdx, desiredIdx));
+				// If not, mark them for creation.
+				if (!found) indexesToCreate.push(desiredIdx);
+			}
+			// Create indexes
+			for (const idx of indexesToCreate) {
+				Logger.info({ message: `MONGODB [${this.collectionName}]: Creating index on keys ${JSON.stringify(idx.key)} with options ${JSON.stringify(prepareMongoIndexOptions(idx))}.` });
+				await this.collection.createIndex(idx.key, prepareMongoIndexOptions(idx) as CreateIndexesOptions);
+				Logger.success(`MONGODB [${this.collectionName}]: Created index on keys ${JSON.stringify(idx.key)}.`);
+			}
+			Logger.success(`MONGODB [${this.collectionName}]: Indexes synchronized.`);
+		} catch (error) {
+			Logger.error({ error, message: `MONGODB [${this.collectionName}]: Error @ syncIndexes(): ${(error as Error).message}` });
+			throw error;
+		}
+	}
+
+	//
+}

--- a/packages-new/interfaces/raw-db/src/interface.template.ts
+++ b/packages-new/interfaces/raw-db/src/interface.template.ts
@@ -2,7 +2,7 @@
 
 import { type SimplifiedMongoIndex } from '@/types/mongo/index-description.js';
 import { isSameIndex, prepareMongoIndexOptions } from '@/utils/mongo/index.js';
-import { AnyBulkWriteOperation, BulkWriteOptions, BulkWriteResult, Collection, CreateIndexesOptions, Db, Filter, FindOptions, InsertOneOptions, WithId } from '@tmlmobilidade/go-clients-mongo';
+import { AnyBulkWriteOperation, BulkWriteOptions, BulkWriteResult, Collection, CreateIndexesOptions, Db, Document, Filter, FindOptions, InsertOneOptions, WithId } from '@tmlmobilidade/go-clients-mongo';
 import { Logger } from '@tmlmobilidade/logger';
 import { z } from 'zod';
 
@@ -19,6 +19,8 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	//
 	private readonly collection: Collection<T>;
 
+	private initPromise: null | Promise<void> = null;
+
 	/**
 	 * @param collectionName - The name of the collection to create the interface for.
 	 * @param database - The database to create the interface for.
@@ -26,10 +28,15 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * @param indexDescription - The index description to use for the collection.
 	 */
 	public constructor(collectionName: string, database: Db, createSchema: z.ZodSchema, indexDescription: false | SimplifiedMongoIndex<T>[] = []) {
+		this.collectionName = collectionName;
 		this.collection = database.collection<T>(collectionName);
 		this.database = database;
 		this.createSchema = createSchema;
 		this.indexDescription = indexDescription;
+		this.initPromise = this.init().catch((error) => {
+			Logger.error({ error, message: `MONGODB [${this.collectionName}]: Error @ constructor(): ${(error as Error).message}` });
+			throw error;
+		});
 	}
 
 	/**
@@ -38,6 +45,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * @returns A promise that resolves to the count of matching documents.
 	 */
 	public async count(filter?: Filter<T>): Promise<number> {
+		await this.ensureInitialized();
 		return await this.collection.countDocuments(filter);
 	}
 
@@ -48,6 +56,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * @returns A promise that resolves to an array of distinct values for the given key.
 	 */
 	public async distinct<Key extends keyof WithId<T>>(key: Key, filter: Filter<T>) {
+		await this.ensureInitialized();
 		return this.collection.distinct(key, filter);
 	}
 
@@ -59,6 +68,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * @returns A promise that resolves to an array of matching documents.
 	 */
 	public async findMany(filter: Filter<T>, options?: FindOptions) {
+		await this.ensureInitialized();
 		return await this.collection.find(filter, options).toArray();
 	}
 
@@ -69,6 +79,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * @returns A promise that resolves to the matching document or null if not found.
 	 */
 	public async findOne(filter: Filter<T>, options?: FindOptions) {
+		await this.ensureInitialized();
 		return await this.collection.findOne(filter, options);
 	}
 
@@ -79,7 +90,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * @warning Use with caution: direct access to the collection allows for executing arbitrary queries.
 	 */
 	public async getCollection(): Promise<Collection<T>> {
-		if (!this.collection) await this.init();
+		await this.ensureInitialized();
 		return this.collection;
 	}
 
@@ -94,6 +105,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * It is the responsibility of the caller to ensure that the operations are valid and conform to the expected schemas.
 	 */
 	public async bulkWrite(operations: AnyBulkWriteOperation<T>[], options?: BulkWriteOptions): Promise<BulkWriteResult> {
+		await this.ensureInitialized();
 		return await this.collection.bulkWrite(operations, options);
 	}
 
@@ -104,6 +116,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * @returns A promise that resolves to the result of the insertMany operation.
 	 */
 	public async insertMany(data: TCreate[], options?: InsertOneOptions) {
+		await this.ensureInitialized();
 		// If no create schema is defined, throw an error.
 		if (!this.createSchema) throw new Error(`No schema defined for insert operation for ${this.collectionName} collection.`);
 		// Validate each document against the create schema
@@ -117,6 +130,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	}
 
 	public async insertOne(data: TCreate, options?: InsertOneOptions) {
+		await this.ensureInitialized();
 		// If no create schema is defined, throw an error.
 		if (!this.createSchema) throw new Error(`No schema defined for insert operation for ${this.collectionName} collection.`);
 		// Validate the document against the create schema
@@ -140,6 +154,11 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 		await this.syncIndexes();
 		// Call postInit for any additional setup logic defined in subclasses
 		await this.postInit();
+	}
+
+	private async ensureInitialized() {
+		if (!this.initPromise) this.initPromise = this.init();
+		await this.initPromise;
 	}
 
 	/**

--- a/packages-new/interfaces/raw-db/src/interface.template.ts
+++ b/packages-new/interfaces/raw-db/src/interface.template.ts
@@ -115,7 +115,7 @@ export class MongoInterfaceTemplate<T extends Document, TCreate> {
 	 * @param options Optional insert options to configure the behavior of the insert operation.
 	 * @returns A promise that resolves to the result of the insertMany operation.
 	 */
-	public async insertMany(data: TCreate[], options?: InsertOneOptions) {
+	public async insertMany(data: TCreate[], options?: BulkWriteOptions) {
 		await this.ensureInitialized();
 		// If no create schema is defined, throw an error.
 		if (!this.createSchema) throw new Error(`No schema defined for insert operation for ${this.collectionName} collection.`);

--- a/packages-new/interfaces/raw-db/src/types/index.ts
+++ b/packages-new/interfaces/raw-db/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './mongo/index.js';

--- a/packages-new/interfaces/raw-db/src/types/mongo/aggregation.ts
+++ b/packages-new/interfaces/raw-db/src/types/mongo/aggregation.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Filter } from 'mongodb';
+
+import { type OptionalIf } from '@tmlmobilidade/types';
+
+interface MatchStage<T> { $match: Filter<T> }
+interface ProjectStage<T> { $project: Partial<Record<keyof T, 0 | 1> | Record<string, 0 | 1>> }
+interface GroupStage {
+	$group: {
+		[key: string]: any
+		_id: Record<string, any> | string
+	}
+}
+interface ReplaceRootStage { $replaceRoot: { newRoot: Record<string, any> | string } }
+interface SortStage<T> { $sort: Partial<Record<keyof T, -1 | 1> | Record<string, -1 | 1>> }
+interface LimitStage { $limit: number }
+interface SkipStage { $skip: number }
+interface UnwindStage { $unwind: string | { path: string, preserveNullAndEmptyArrays: boolean } }
+interface AddFieldsStage { $addFields: Record<string, any> }
+interface LookupStage {
+	$lookup: OptionalIf<{
+		as: string
+		foreignField?: string
+		from: string
+		let?: Record<string, any>
+		localField?: string
+		pipeline?: any[]
+	}, 'pipeline', 'foreignField' | 'localField'>
+}
+interface SetStage { $set: Record<string, any> }
+interface UnsetStage { $unset: string | string[] }
+
+type AggregationStage<T> =
+  | AddFieldsStage
+  | GroupStage
+  | LimitStage
+  | LookupStage
+  | MatchStage<T>
+  | ProjectStage<T>
+  | ReplaceRootStage
+  | SetStage
+  | SkipStage
+  | SortStage<T>
+  | UnsetStage
+  | UnwindStage;
+
+export type AggregationPipeline<T> = AggregationStage<T>[];

--- a/packages-new/interfaces/raw-db/src/types/mongo/index-description.ts
+++ b/packages-new/interfaces/raw-db/src/types/mongo/index-description.ts
@@ -1,0 +1,10 @@
+/* * */
+
+import type { IndexSpecification } from 'mongodb';
+
+export interface SimplifiedMongoIndex<T> {
+	expireAfterSeconds?: number
+	key: IndexSpecification
+	sparse?: boolean
+	unique?: boolean
+}

--- a/packages-new/interfaces/raw-db/src/types/mongo/index.ts
+++ b/packages-new/interfaces/raw-db/src/types/mongo/index.ts
@@ -1,0 +1,1 @@
+export * from './index-description.js';

--- a/packages-new/interfaces/raw-db/src/utils/index.ts
+++ b/packages-new/interfaces/raw-db/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './mongo/index.js';

--- a/packages-new/interfaces/raw-db/src/utils/mongo/index.ts
+++ b/packages-new/interfaces/raw-db/src/utils/mongo/index.ts
@@ -1,0 +1,1 @@
+export * from './manage-indexes.js';

--- a/packages-new/interfaces/raw-db/src/utils/mongo/manage-indexes.ts
+++ b/packages-new/interfaces/raw-db/src/utils/mongo/manage-indexes.ts
@@ -1,0 +1,33 @@
+/* * */
+
+import type { SimplifiedMongoIndex } from '@/types/mongo/index-description.js';
+import type { CreateIndexesOptions, IndexDescriptionInfo } from 'mongodb';
+
+export function prepareMongoIndexOptions<T>(idx: SimplifiedMongoIndex<T>): CreateIndexesOptions {
+	const result: CreateIndexesOptions = {};
+	if (idx.expireAfterSeconds !== undefined) result.expireAfterSeconds = idx.expireAfterSeconds;
+	if (idx.sparse !== undefined) result.sparse = idx.sparse;
+	if (idx.unique !== undefined) result.unique = idx.unique;
+	return result;
+}
+
+function normalizeMongoIndex<T>(indexDescription: IndexDescriptionInfo | SimplifiedMongoIndex<T>): SimplifiedMongoIndex<T> {
+	return {
+		expireAfterSeconds: indexDescription.expireAfterSeconds ?? undefined,
+		key: indexDescription.key as Record<keyof T, -1 | 1>,
+		sparse: !!indexDescription.sparse,
+		unique: !!indexDescription.unique,
+	};
+}
+
+export function isSameIndex<T>(a: IndexDescriptionInfo | SimplifiedMongoIndex<T>, b: IndexDescriptionInfo | SimplifiedMongoIndex<T>): boolean {
+	const normalizedA = normalizeMongoIndex(a);
+	const normalizedB = normalizeMongoIndex(b);
+	const aKeySorted = Object.fromEntries(Object.entries(normalizedA.key).sort());
+	const bKeySorted = Object.fromEntries(Object.entries(normalizedB.key).sort());
+	const matchingKeys = JSON.stringify(aKeySorted) === JSON.stringify(bKeySorted);
+	const matchingUnique = !!normalizedA.unique === !!normalizedB.unique;
+	const matchingSparse = !!normalizedA.sparse === !!normalizedB.sparse;
+	const matchingExpire = normalizedA.expireAfterSeconds === normalizedB.expireAfterSeconds;
+	return matchingKeys && matchingUnique && matchingSparse && matchingExpire;
+}

--- a/packages-new/interfaces/raw-db/tsconfig.json
+++ b/packages-new/interfaces/raw-db/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "@tmlmobilidade/tsconfig/lib.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"rootDir": "src",
+		"strictNullChecks": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Add a new `@tmlmobilidade/go-interfaces-raw-db` package providing a typed MongoDB interface for the `raw` database, following the established `go-db` pattern. This replaces the flat singleton imports from `@tmlmobilidade/databases` with a structured, singleton-based API.

## Changes

- **New `raw-db` package**: Scaffolded `packages-new/interfaces/raw-db/` with `package.json`, `tsconfig.json`, and build tooling
- **`RawDatabase` class**: Groups collections under the `raw` database namespace (`rawApexTransactions`, `rawVehicleEvents`) with Zod schema validation
- **`RawDBClass` singleton**: Manages MongoDB connection via `MongoDatabaseClient.getClient({ prefix: 'RAW_DB' })` with lazy initialization
- **`RawDb` export**: Singleton proxy exported for consumer use
- **`MongoInterfaceTemplate`**: Fully-featured template with `count`, `distinct`, `findMany`, `findOne`, `insertOne`, `insertMany`, `bulkWrite`, auto-index synchronization, and collection creation
- **Auto-index sync**: Ensures collection exists on init and synchronizes indexes from a declarative description
- **`go-clients-mongo` exports**: Re-exported `CreateIndexesOptions` type from mongodb for use by consumers

Closes GO-652