### PR TITLE
refactor(auth): migrate session cleanup to goDb.core.sessions

### DIFF
--- a/modules/auth/apps/cleaner/src/tasks/clean-sessions.ts
+++ b/modules/auth/apps/cleaner/src/tasks/clean-sessions.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { Dates } from '@tmlmobilidade/dates';
-import { sessions } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';
 
@@ -14,10 +14,9 @@ export async function cleanExpiredSessions() {
 		const timer = new Timer();
 		Logger.info({ message: `Cleaning expired "sessions" documents...` });
 		const now = Dates.now('Europe/Lisbon').unix_timestamp;
-		const deleteResult = await sessions.deleteMany({ expires_at: { $lt: now } });
+		const deleteResult = await goDB.core.sessions.deleteMany({ expires_at: { $lt: now } });
 		Logger.success(`Deleted ${deleteResult.deletedCount} expired "sessions" documents in ${timer.get()}.`);
-	}
-	catch (error) {
+	} catch (error) {
 		Logger.error({ error, message: `Failed to clean expired "sessions" documents:` });
 	}
 }

--- a/packages/interfaces/src/providers/auth/auth.ts
+++ b/packages/interfaces/src/providers/auth/auth.ts
@@ -1,8 +1,9 @@
 /* * */
 
-import { organizations, roles, sessions, users, verificationTokens } from '@/interfaces/index.js';
+import { organizations, roles, users, verificationTokens } from '@/interfaces/index.js';
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { Dates } from '@tmlmobilidade/dates';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { generateRandomString, generateRandomToken } from '@tmlmobilidade/strings';
 import { type CreateUserDto, type LoginDto, type Organization, type Permission, type Session, type User } from '@tmlmobilidade/types';
 import { asyncSingletonProxy, mergeObjects } from '@tmlmobilidade/utils';
@@ -96,7 +97,7 @@ class AuthProvider {
 	 */
 	public async getUserFromSessionToken(sessionToken: string): Promise<User> {
 		// Find the current session in the database
-		const sessionData = await sessions.findOne({ token: { $eq: sessionToken } });
+		const sessionData = await goDB.core.sessions.findOne({ token: { $eq: sessionToken } });
 		if (!sessionData) throw new HttpException(HTTP_STATUS.UNAUTHORIZED, 'Session not found');
 		// Find the user associated with the session
 		const userData = await users.findOne({ _id: { $eq: sessionData.user_id } });
@@ -135,7 +136,7 @@ class AuthProvider {
 			user_id: userData._id.toString(),
 		};
 		// Insert the new session into the database
-		await sessions.insertOne(newSession);
+		await goDB.core.sessions.insertOne(newSession);
 		// Return the session to the caller
 		return newSession;
 	}
@@ -145,7 +146,7 @@ class AuthProvider {
 	 * @param sessionToken The session token to logout.
 	 */
 	public async logout(sessionToken: string): Promise<void> {
-		await sessions.deleteOne({ token: { $eq: sessionToken } });
+		await goDB.core.sessions.deleteOne({ token: { $eq: sessionToken } });
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Migrate session cleanup from importing `sessions` from `@tmlmobilidade/interfaces` to using `goDb.core.sessions` so auth maintenance jobs follow the new database access pattern.

## Changes

- **clean-sessions.ts**: Replace `sessions` import with `goDb.core.sessions`, preserving cleanup filters exactly

Closes https://linear.app/cmetropolitana/issue/GO-605/add-godbcoresessions-access-to-session-callers