### PR TITLE
refactor(roles): migrate role operations to goDb.core.roles

### DIFF
--- a/modules/auth/apps/api/src/endpoints/roles/roles.controller.ts
+++ b/modules/auth/apps/api/src/endpoints/roles/roles.controller.ts
@@ -2,7 +2,7 @@
 
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
-import { roles } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { type CreateRoleDto, type Role, type UpdateRoleDto } from '@tmlmobilidade/types';
 
 /* * */
@@ -23,7 +23,7 @@ export class RolesController {
 		request.body.created_by = request.me._id;
 		request.body.updated_by = request.me._id;
 
-		const role = await roles.insertOne(request.body);
+		const role = await goDB.core.roles.insertOne(request.body);
 
 		if (!role) {
 			throw new HttpException(HTTP_STATUS.INTERNAL_SERVER_ERROR, 'Error creating role');
@@ -38,7 +38,7 @@ export class RolesController {
 	 * @param {FastifyReply} reply - The reply object
 	 */
 	static async delete(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<void>) {
-		const result = await roles.deleteById(request.params.id);
+		const result = await goDB.core.roles.deleteById(request.params.id);
 		if (!result) {
 			throw new HttpException(HTTP_STATUS.INTERNAL_SERVER_ERROR, 'Error deleting role');
 		}
@@ -52,7 +52,7 @@ export class RolesController {
 	 * @param {FastifyReply} reply - The reply object
 	 */
 	static async getAll(request: FastifyRequest, reply: FastifyReply<Role[]>) {
-		const allRolesData = await roles.findMany({}, { sort: { name: 1 } });
+		const allRolesData = await goDB.core.roles.findMany({}, { sort: { name: 1 } });
 
 		if (!allRolesData) {
 			throw new HttpException(HTTP_STATUS.INTERNAL_SERVER_ERROR, 'Error getting roles');
@@ -67,7 +67,7 @@ export class RolesController {
 	 * @param {FastifyReply} reply - The reply object
 	 */
 	static async getById(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<Role>) {
-		const role = await roles.findById(request.params.id);
+		const role = await goDB.core.roles.findById(request.params.id);
 
 		if (!role) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Role not found');
@@ -82,8 +82,8 @@ export class RolesController {
 	 * @param reply Fastify reply.
 	 */
 	static async lock(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<Role>) {
-		await roles.toggleLockById(request.params.id);
-		const foundRole = await roles.findById(request.params.id);
+		await goDB.core.roles.toggleLockById(request.params.id);
+		const foundRole = await goDB.core.roles.findById(request.params.id);
 		if (!foundRole) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Role not found');
 		}
@@ -103,7 +103,7 @@ export class RolesController {
 		// Set the updated_by field to the current user's id
 		request.body.updated_by = request.me._id;
 
-		const role = await roles.updateById(request.params.id, request.body);
+		const role = await goDB.core.roles.updateById(request.params.id, request.body);
 
 		if (!role) {
 			throw new HttpException(HTTP_STATUS.INTERNAL_SERVER_ERROR, 'Error updating role');

--- a/modules/auth/apps/cleaner/src/tasks/sanitize-permissions.ts
+++ b/modules/auth/apps/cleaner/src/tasks/sanitize-permissions.ts
@@ -1,6 +1,7 @@
 /* * */
 
-import { roles, users } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
+import { users } from '@tmlmobilidade/interfaces';
 import { Logger } from '@tmlmobilidade/logger';
 import { Timer } from '@tmlmobilidade/timer';
 import { PermissionCatalog } from '@tmlmobilidade/types';
@@ -33,11 +34,11 @@ export async function sanitizePermissions() {
 
 		const rolesTimer = new Timer();
 
-		const allRoles = await roles.findMany();
+		const allRoles = await goDB.core.roles.findMany();
 
 		for (const role of allRoles) {
 			const sanitizedPermissions = PermissionCatalog.sanitize(role.permissions);
-			await roles.updateById(role._id, { permissions: sanitizedPermissions });
+			await goDB.core.roles.updateById(role._id, { permissions: sanitizedPermissions });
 		}
 
 		Logger.success(`Updated ${allRoles.length} roles with sanitized permissions in ${rolesTimer.get()}.`);

--- a/packages/interfaces/src/interfaces/notifications/notifications.ts
+++ b/packages/interfaces/src/interfaces/notifications/notifications.ts
@@ -1,9 +1,9 @@
 /* * */
 
 import { MongoCollectionClass } from '@/common/mongo-collection.js';
-import { roles } from '@/interfaces/auth/roles.js';
 import { users } from '@/interfaces/auth/users.js';
 import { getModuleConfig } from '@tmlmobilidade/consts';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { type CreateNotificationDto, CreateNotificationSchema, type Notification, NotificationPermission, Permission, Role, UpdateNotificationDto, UpdateNotificationSchema, User } from '@tmlmobilidade/types';
 import { asyncSingletonProxy, mergeObjects } from '@tmlmobilidade/utils';
 import { IndexDescription } from 'mongodb';
@@ -39,7 +39,7 @@ class NotificationsClass extends MongoCollectionClass<Notification, CreateNotifi
 		description: string,
 	): Promise<void> {
 		// Fetch roles and users that have access to this topic
-		const rolesWithTopic = await roles.findMany({ 'permissions.action': topic });
+		const rolesWithTopic = await goDB.core.roles.findMany({ 'permissions.action': topic });
 		const roleIdsWithTopic = rolesWithTopic.map(r => r._id);
 
 		const usersWithTopic = await users.findMany({

--- a/packages/interfaces/src/providers/auth/auth.ts
+++ b/packages/interfaces/src/providers/auth/auth.ts
@@ -1,8 +1,9 @@
 /* * */
 
-import { organizations, roles, sessions, users, verificationTokens } from '@/interfaces/index.js';
+import { organizations, sessions, users, verificationTokens } from '@/interfaces/index.js';
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { Dates } from '@tmlmobilidade/dates';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { generateRandomString, generateRandomToken } from '@tmlmobilidade/strings';
 import { type CreateUserDto, type LoginDto, type Organization, type Permission, type Session, type User } from '@tmlmobilidade/types';
 import { asyncSingletonProxy, mergeObjects } from '@tmlmobilidade/utils';
@@ -65,7 +66,7 @@ class AuthProvider {
 		const userData = await users.findById(userId);
 		if (!userData) throw new HttpException(HTTP_STATUS.UNAUTHORIZED, 'User not found.');
 		// Get the roles assigned to the user
-		const rolesData = await roles.findMany({ _id: { $in: userData.role_ids } });
+		const rolesData = await goDB.core.roles.findMany({ _id: { $in: userData.role_ids } });
 		// Combine permissions from roles and user-specific permissions
 		const allPermissions = [...rolesData.flatMap(role => role.permissions), ...userData.permissions];
 		// Merge permissions with the same scope and action


### PR DESCRIPTION
## Summary

Migrate role callers from importing `roles` from `@tmlmobilidade/interfaces` to using `goDb.core.roles` as part of the database access migration for auth.

## Changes

- **roles.controller.ts**: Replace `roles` import with `goDb.core.roles` across all role CRUD endpoints
- **sanitize-permissions.ts**: Update permission sanitization to use goDb

Closes https://linear.app/cmetropolitana/issue/GO-604/add-godbcoreroles-access-to-role-callers