### PR TITLE
feat(zones): migrate zone operations to goDb.offer.zones

### DIFF
--- a/modules/offer/apps/api/src/endpoints/zones/zones.controller.ts
+++ b/modules/offer/apps/api/src/endpoints/zones/zones.controller.ts
@@ -2,7 +2,8 @@
 
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
-import { type Filter, zones } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
+import { type Filter } from '@tmlmobilidade/interfaces';
 import { CreateZoneDto, PermissionCatalog, type PermissionResourceCheck, type UpdateZoneDto, type Zone } from '@tmlmobilidade/types';
 
 /* * */;
@@ -56,7 +57,7 @@ export class ZonesController {
 		//
 		// Create the new zone
 
-		const newZone = await zones.insertOne(request.body);
+		const newZone = await goDB.offer.zones.insertOne(request.body);
 
 		//
 		// Send the response
@@ -73,7 +74,7 @@ export class ZonesController {
 	 */
 	static async delete(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<void>) {
 		const { id } = request.params;
-		const zone = await zones.findById(id);
+		const zone = await goDB.offer.zones.findById(id);
 
 		if (!zone) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Zone not found');
@@ -108,7 +109,7 @@ export class ZonesController {
 
 		//
 
-		await zones.deleteById(id);
+		await goDB.offer.zones.deleteById(id);
 
 		reply.send({ data: undefined, error: null, statusCode: HTTP_STATUS.OK });
 	}
@@ -136,7 +137,7 @@ export class ZonesController {
 		//
 		// Fetch zones based on query filters
 
-		const allZones = await zones.findMany(queryFilters, { sort: { created_at: -1 } });
+		const allZones = await goDB.offer.zones.findMany(queryFilters, { sort: { created_at: -1 } });
 
 		return reply.send({ data: allZones, error: null, statusCode: HTTP_STATUS.OK });
 		//
@@ -153,7 +154,7 @@ export class ZonesController {
 		//
 		// Get the Zone from the database
 
-		const zoneData = await zones.findById(request.params.id);
+		const zoneData = await goDB.offer.zones.findById(request.params.id);
 
 		if (!zoneData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Zone not found');
@@ -194,7 +195,7 @@ export class ZonesController {
 		//
 		// Get the Zone from the database
 
-		const zoneData = await zones.findById(request.params.id);
+		const zoneData = await goDB.offer.zones.findById(request.params.id);
 
 		if (!zoneData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Zone not found');
@@ -228,8 +229,8 @@ export class ZonesController {
 		}
 
 		// If authorized, toggle the lock status of the zone
-		await zones.toggleLockById(request.params.id);
-		const foundZone = await zones.findById(request.params.id);
+		await goDB.offer.zones.toggleLockById(request.params.id);
+		const foundZone = await goDB.offer.zones.findById(request.params.id);
 		if (!foundZone) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Zone not found');
 		}
@@ -250,7 +251,7 @@ export class ZonesController {
 		//
 		// Get the Zone from the database
 
-		const zoneData = await zones.findById(request.params.id);
+		const zoneData = await goDB.offer.zones.findById(request.params.id);
 
 		if (!zoneData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Zone not found');
@@ -286,7 +287,7 @@ export class ZonesController {
 		//
 		// Update the zone
 
-		const updatedZone = await zones.updateById(zoneData._id, request.body);
+		const updatedZone = await goDB.offer.zones.updateById(zoneData._id, request.body);
 
 		//
 		// Send the updated zone data as the response

--- a/modules/offer/apps/gtfs-exporter/src/fetchers/zone.ts
+++ b/modules/offer/apps/gtfs-exporter/src/fetchers/zone.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { zones } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { Logger } from '@tmlmobilidade/logger';
 import { type Zone } from '@tmlmobilidade/types';
 
@@ -15,7 +15,7 @@ export async function fetchAllZones(): Promise<Map<string, Zone>> {
 	try {
 		Logger.info({ message: 'Fetching all zones...' });
 
-		const allZones = await zones.findMany({});
+		const allZones = await goDB.offer.zones.findMany({});
 		const zonesMap = new Map<string, Zone>();
 
 		for (const zone of allZones) {

--- a/modules/offer/apps/gtfs-importer/src/index.context.ts
+++ b/modules/offer/apps/gtfs-importer/src/index.context.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { encodePolylineFromGeoJson } from '@tmlmobilidade/geo';
-import { zones } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { type Shape } from '@tmlmobilidade/types';
 
 import { fetchTypologiesByAgencyIds } from './fetchers/typology.js';
@@ -83,7 +83,7 @@ export async function buildImportContext(options: ImportOptions): Promise<Import
 		mappedColors: typologyMap.size,
 	});
 
-	const zoneDocs = await zones.findMany({});
+	const zoneDocs = await goDB.offer.zones.findMany({});
 	const zoneIdByCode = new Map<string, string>();
 	for (const zone of zoneDocs) {
 		if (!zone.code) continue;

--- a/modules/offer/helpers/seed-zones/src/index.ts
+++ b/modules/offer/helpers/seed-zones/src/index.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { seedFromGoV1 } from '@/tasks/seed-from-go-v1.js';
-import { zones } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 
 /* * */
 
@@ -12,7 +12,7 @@ import { zones } from '@tmlmobilidade/interfaces';
 	// Delete existing zones
 
 	console.log('Deleting All');
-	await zones.deleteMany({});
+	await goDB.offer.zones.deleteMany({});
 
 	//
 	// Run tasks

--- a/modules/offer/helpers/seed-zones/src/tasks/seed-from-go-v1.ts
+++ b/modules/offer/helpers/seed-zones/src/tasks/seed-from-go-v1.ts
@@ -2,7 +2,7 @@
 
 import { type OriginalZoneType } from '@/original-zone.type.js';
 import { Dates } from '@tmlmobilidade/dates';
-import { zones } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { generateRandomString } from '@tmlmobilidade/strings';
 import { ZoneSchema } from '@tmlmobilidade/types';
 
@@ -76,7 +76,7 @@ export async function seedFromGoV1() {
 		//
 		// Insert zones into DB
 
-		await zones.insertMany(preparedZones, { unsafe: true });
+		await goDB.offer.zones.insertMany(preparedZones, { unsafe: true });
 		console.log(`Inserted ${preparedZones.length} zones`);
 
 		//


### PR DESCRIPTION
## Summary

Migrate zone callers from importing `zones` from `@tmlmobilidade/interfaces` to using `goDb.offer.zones` under the new offer database namespace.

## Changes

- **zones.controller.ts**: Replace `zones` import with `goDb.offer.zones`
- **gtfs-exporter fetchers/zone.ts**: Migrate zone fetcher to goDb
- **gtfs-importer index.context.ts**: Update zone import context to goDb
- **seed-zones**: Migrate seed tasks to goDb

Closes https://linear.app/cmetropolitana/issue/GO-622/add-godbofferzones-access-to-zone-callers