### PR TITLE
feat(year-periods): migrate year period data access to goDb.offer.yearPeriods

### DIFF
--- a/modules/dates/apps/api/src/endpoints/year-periods/year-periods.controller.ts
+++ b/modules/dates/apps/api/src/endpoints/year-periods/year-periods.controller.ts
@@ -3,7 +3,8 @@
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { findCommonDates, mergeDateArrays, removeDatesFromArray } from '@tmlmobilidade/dates';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
-import { type Filter, yearPeriods } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
+import { type Filter } from '@tmlmobilidade/interfaces';
 import { type CreateYearPeriodDto, OperationalDate, PermissionCatalog, type UpdateYearPeriodDto, type YearPeriod } from '@tmlmobilidade/types';
 
 /* * */
@@ -72,7 +73,7 @@ export class YearPeriodsController {
 			query._id = { $ne: year_period_id };
 		}
 
-		const agencyPeriods = await yearPeriods.findMany(query);
+		const agencyPeriods = await goDB.offer.yearPeriods.findMany(query);
 
 		//
 		// Helper function to check if two agency arrays are exactly the same (regardless of order)
@@ -167,7 +168,7 @@ export class YearPeriodsController {
 		//
 		// Create the new period
 
-		const newPeriod = await yearPeriods.insertOne(request.body);
+		const newPeriod = await goDB.offer.yearPeriods.insertOne(request.body);
 
 		//
 		// Send the response
@@ -184,7 +185,7 @@ export class YearPeriodsController {
 	 */
 	static async delete(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<void>) {
 		const { id } = request.params;
-		const period = await yearPeriods.findById(id);
+		const period = await goDB.offer.yearPeriods.findById(id);
 
 		if (!period) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'YearPeriod not found');
@@ -219,7 +220,7 @@ export class YearPeriodsController {
 
 		//
 
-		await yearPeriods.deleteById(id);
+		await goDB.offer.yearPeriods.deleteById(id);
 
 		reply.send({ data: undefined, error: null, statusCode: HTTP_STATUS.OK });
 	}
@@ -262,7 +263,7 @@ export class YearPeriodsController {
 		//
 		// Fetch year periods based on query filters
 
-		const allYearPeriods = await yearPeriods.findMany(queryFilters, { sort: { start_date: -1 } });
+		const allYearPeriods = await goDB.offer.yearPeriods.findMany(queryFilters, { sort: { start_date: -1 } });
 		return reply.send({ data: allYearPeriods, error: null, statusCode: HTTP_STATUS.OK });
 
 		//
@@ -279,7 +280,7 @@ export class YearPeriodsController {
 		//
 		// Get the YearPeriod from the database
 
-		const periodData = await yearPeriods.findById(request.params.id);
+		const periodData = await goDB.offer.yearPeriods.findById(request.params.id);
 		if (!periodData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'YearPeriod not found');
 		}
@@ -335,7 +336,7 @@ export class YearPeriodsController {
 		//
 		// Get the YearPeriod from the database
 
-		const periodData = await yearPeriods.findById(request.params.id);
+		const periodData = await goDB.offer.yearPeriods.findById(request.params.id);
 
 		if (!periodData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'YearPeriod not found');
@@ -371,8 +372,8 @@ export class YearPeriodsController {
 		//
 		// Toggle the lock status of the period
 
-		await yearPeriods.toggleLockById(request.params.id);
-		const updatedPeriod = await yearPeriods.findById(request.params.id);
+		await goDB.offer.yearPeriods.toggleLockById(request.params.id);
+		const updatedPeriod = await goDB.offer.yearPeriods.findById(request.params.id);
 		if (!updatedPeriod) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'YearPeriod not found');
 		}
@@ -398,7 +399,7 @@ export class YearPeriodsController {
 		//
 		// Get the YearPeriod from the database
 
-		const periodData = await yearPeriods.findById(request.params.id);
+		const periodData = await goDB.offer.yearPeriods.findById(request.params.id);
 
 		if (!periodData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'YearPeriod not found');
@@ -448,7 +449,7 @@ export class YearPeriodsController {
 		//
 		// Update the period
 
-		const updatedPeriod = await yearPeriods.updateById(periodData._id, request.body);
+		const updatedPeriod = await goDB.offer.yearPeriods.updateById(periodData._id, request.body);
 
 		//
 		// Send the updated period data as the response
@@ -494,7 +495,7 @@ export class YearPeriodsController {
 			query._id = { $ne: yearPeriodId };
 		}
 
-		const agencyPeriods = await yearPeriods.findMany(query);
+		const agencyPeriods = await goDB.offer.yearPeriods.findMany(query);
 
 		//
 		// Helper function to check if two agency arrays are exactly the same (regardless of order)
@@ -521,7 +522,7 @@ export class YearPeriodsController {
 			if (conflicts.length > 0) {
 				// Remove conflicting dates from this year period
 				const updatedDates = removeDatesFromArray(otherPeriod.dates, conflicts);
-				await yearPeriods.updateById(otherPeriod._id, { dates: updatedDates });
+				await goDB.offer.yearPeriods.updateById(otherPeriod._id, { dates: updatedDates });
 			}
 		}
 

--- a/modules/dates/seed-periods/src/tasks/seed-from-go-v1.ts
+++ b/modules/dates/seed-periods/src/tasks/seed-from-go-v1.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { yearPeriods } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { type OperationalDate } from '@tmlmobilidade/types';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -80,7 +80,7 @@ export async function seedFromGoV1() {
 			const startDate = sortedDates[0];
 			const endDate = sortedDates[sortedDates.length - 1];
 
-			await yearPeriods.updateOne(
+			await goDB.offer.yearPeriods.updateOne(
 				{ _id: yearPeriodId },
 				{
 					dates: datesToUpdate as OperationalDate[],
@@ -94,8 +94,7 @@ export async function seedFromGoV1() {
 		console.log('All periods updated successfully');
 
 		//
-	}
-	catch (err) {
+	} catch (err) {
 		console.error('Error updating periods:', err);
 		process.exit(1);
 	}

--- a/modules/offer/apps/gtfs-exporter/src/fetchers/year-periods.ts
+++ b/modules/offer/apps/gtfs-exporter/src/fetchers/year-periods.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { yearPeriods } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { YearPeriod } from '@tmlmobilidade/types';
 
 /* * */
@@ -11,14 +11,13 @@ import { YearPeriod } from '@tmlmobilidade/types';
  */
 export async function fetchAllYearPeriods(): Promise<Map<string, YearPeriod>> {
 	try {
-		const allPeriods = await yearPeriods.findMany({});
+		const allPeriods = await goDB.offer.yearPeriods.findMany({});
 		const periodsMap = new Map<string, YearPeriod>();
 		for (const period of allPeriods) {
 			periodsMap.set(period._id, period);
 		}
 		return periodsMap;
-	}
-	catch (error) {
+	} catch (error) {
 		throw new Error(`Error fetching periods: ${error}`);
 	}
 }


### PR DESCRIPTION
## Summary

Migrate year period callers from importing `yearPeriods` from `@tmlmobilidade/interfaces` to using `goDb.offer.yearPeriods` under the new database access interface.

## Changes

- **year-periods.controller.ts**: Replace `yearPeriods` import with `goDb.offer.yearPeriods`
- **gtfs-exporter fetchers/year-periods.ts**: Migrate year period fetcher to goDb
- **seed-periods seed-from-go-v1.ts**: Update seed task to use goDb

Closes https://linear.app/cmetropolitana/issue/GO-621/add-godbofferyearperiods-access-to-year-period-callers