### PR TITLE
feat(fares): migrate fare operations to goDb.offer.fares

### DIFF
--- a/modules/offer/apps/api/src/endpoints/fares/fares.controller.ts
+++ b/modules/offer/apps/api/src/endpoints/fares/fares.controller.ts
@@ -2,7 +2,8 @@
 
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
-import { fares, type Filter } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
+import { type Filter } from '@tmlmobilidade/interfaces';
 import { CreateFareDto, type Fare, PermissionCatalog, type PermissionResourceCheck, type UpdateFareDto } from '@tmlmobilidade/types';
 
 /* * */;
@@ -56,7 +57,7 @@ export class FaresController {
 		//
 		// Create the new fare
 
-		const newFare = await fares.insertOne(request.body);
+		const newFare = await goDB.offer.fares.insertOne(request.body);
 
 		//
 		// Send the response
@@ -73,7 +74,7 @@ export class FaresController {
 	 */
 	static async delete(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<void>) {
 		const { id } = request.params;
-		const fare = await fares.findById(id);
+		const fare = await goDB.offer.fares.findById(id);
 
 		if (!fare) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Fare not found');
@@ -108,7 +109,7 @@ export class FaresController {
 
 		//
 
-		await fares.deleteById(id);
+		await goDB.offer.fares.deleteById(id);
 
 		reply.send({ data: undefined, error: null, statusCode: HTTP_STATUS.OK });
 	}
@@ -136,7 +137,7 @@ export class FaresController {
 		//
 		// Fetch fares based on query filters
 
-		const allFares = await fares.findMany(queryFilters, { sort: { created_at: -1 } });
+		const allFares = await goDB.offer.fares.findMany(queryFilters, { sort: { created_at: -1 } });
 
 		return reply.send({ data: allFares, error: null, statusCode: HTTP_STATUS.OK });
 		//
@@ -153,7 +154,7 @@ export class FaresController {
 		//
 		// Get the Fare from the database
 
-		const fareData = await fares.findById(request.params.id);
+		const fareData = await goDB.offer.fares.findById(request.params.id);
 
 		if (!fareData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Fare not found');
@@ -194,7 +195,7 @@ export class FaresController {
 		//
 		// Get the Fare from the database
 
-		const fareData = await fares.findById(request.params.id);
+		const fareData = await goDB.offer.fares.findById(request.params.id);
 
 		if (!fareData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Fare not found');
@@ -228,8 +229,8 @@ export class FaresController {
 		}
 
 		// If authorized, toggle the lock status of the fare
-		await fares.toggleLockById(request.params.id);
-		const foundFare = await fares.findById(request.params.id);
+		await goDB.offer.fares.toggleLockById(request.params.id);
+		const foundFare = await goDB.offer.fares.findById(request.params.id);
 		if (!foundFare) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Fare not found');
 		}
@@ -250,7 +251,7 @@ export class FaresController {
 		//
 		// Get the Fare from the database
 
-		const fareData = await fares.findById(request.params.id);
+		const fareData = await goDB.offer.fares.findById(request.params.id);
 
 		if (!fareData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Fare not found');
@@ -286,7 +287,7 @@ export class FaresController {
 		//
 		// Update the fare
 
-		const updatedFare = await fares.updateById(fareData._id, request.body);
+		const updatedFare = await goDB.offer.fares.updateById(fareData._id, request.body);
 
 		//
 		// Send the updated fare data as the response

--- a/modules/offer/apps/gtfs-exporter/src/fetchers/fare.ts
+++ b/modules/offer/apps/gtfs-exporter/src/fetchers/fare.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { fares } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { Fare } from '@tmlmobilidade/types';
 
 /* * */
@@ -11,7 +11,7 @@ import { Fare } from '@tmlmobilidade/types';
  */
 export async function fetchAllFares(): Promise<Map<string, Fare>> {
 	try {
-		const allFares = await fares.findMany({});
+		const allFares = await goDB.offer.fares.findMany({});
 		const faresMap = new Map<string, Fare>();
 		for (const fare of allFares) {
 			faresMap.set(fare._id, fare);

--- a/modules/offer/helpers/seed-fares/src/index.ts
+++ b/modules/offer/helpers/seed-fares/src/index.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { seedFromGoV1 } from '@/tasks/seed-from-go-v1.js';
-import { fares } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 
 /* * */
 
@@ -12,7 +12,7 @@ import { fares } from '@tmlmobilidade/interfaces';
 	// Delete existing fares
 
 	console.log('Deleting All');
-	await fares.deleteMany({});
+	await goDB.offer.fares.deleteMany({});
 
 	//
 	// Run tasks

--- a/modules/offer/helpers/seed-fares/src/tasks/seed-from-go-v1.ts
+++ b/modules/offer/helpers/seed-fares/src/tasks/seed-from-go-v1.ts
@@ -2,7 +2,7 @@
 
 import { type OriginalFareType } from '@/original-fare.type.js';
 import { Dates } from '@tmlmobilidade/dates';
-import { fares } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { generateRandomString } from '@tmlmobilidade/strings';
 import { type Fare, FARE_CURRENCY, FARE_PAYMENT_METHOD, FARE_TRANSFERS, FareSchema } from '@tmlmobilidade/types';
 
@@ -52,7 +52,7 @@ export async function seedFromGoV1() {
 		//
 		// Insert fares into DB
 
-		await fares.insertMany(preparedFares, { unsafe: true });
+		await goDB.offer.fares.insertMany(preparedFares, { unsafe: true });
 		console.log(`Inserted ${preparedFares.length} fares`);
 
 		//


### PR DESCRIPTION
## Summary

Migrate fare callers from importing `fares` from `@tmlmobilidade/interfaces` to using `goDb.offer.fares` under the new offer database interface.

## Changes

- **fares.controller.ts**: Replace `fares` import with `goDb.offer.fares`
- **gtfs-exporter fetchers/fare.ts**: Migrate fare fetcher to goDb
- **seed-fares index.ts**: Update seed task to use goDb
- **seed-fares seed-from-go-v1.ts**: Update legacy seed task to use goDb

Closes https://linear.app/cmetropolitana/issue/GO-615/add-godbofferfares-access-to-fare-callers