### PR TITLE
feat(events): migrate event data access to goDb.offer.events

### DIFF
--- a/modules/dates/apps/api/src/endpoints/events/events.controller.ts
+++ b/modules/dates/apps/api/src/endpoints/events/events.controller.ts
@@ -2,7 +2,8 @@
 
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
-import { events, type Filter, patterns } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
+import { type Filter, patterns } from '@tmlmobilidade/interfaces';
 import { type CreateEventDto, type Event, PermissionCatalog, type UpdateEventDto } from '@tmlmobilidade/types';
 
 /* * */
@@ -48,7 +49,7 @@ export class EventsController {
 		//
 		// Create the new event
 
-		const newEvent = await events.insertOne(request.body);
+		const newEvent = await goDB.offer.events.insertOne(request.body);
 
 		//
 		// Send the response
@@ -65,7 +66,7 @@ export class EventsController {
 	 */
 	static async delete(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<void>) {
 		const { id } = request.params;
-		const event = await events.findById(id);
+		const event = await goDB.offer.events.findById(id);
 
 		if (!event) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Event not found');
@@ -100,7 +101,7 @@ export class EventsController {
 
 		//
 
-		await events.deleteById(id);
+		await goDB.offer.events.deleteById(id);
 
 		reply.send({ data: undefined, error: null, statusCode: HTTP_STATUS.OK });
 	}
@@ -143,7 +144,7 @@ export class EventsController {
 		//
 		// Fetch events based on query filters
 
-		const allEvents = await events.findMany(queryFilters, { sort: { created_at: -1 } });
+		const allEvents = await goDB.offer.events.findMany(queryFilters, { sort: { created_at: -1 } });
 
 		return reply.send({ data: allEvents, error: null, statusCode: HTTP_STATUS.OK });
 
@@ -161,7 +162,7 @@ export class EventsController {
 		//
 		// Get the Event from the database
 
-		const eventData = await events.findById(request.params.id);
+		const eventData = await goDB.offer.events.findById(request.params.id);
 
 		if (!eventData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Event not found');
@@ -244,7 +245,7 @@ export class EventsController {
 		//
 		// Get the Event from the database
 
-		const eventData = await events.findById(request.params.id);
+		const eventData = await goDB.offer.events.findById(request.params.id);
 
 		if (!eventData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Event not found');
@@ -278,8 +279,8 @@ export class EventsController {
 		}
 
 		// If authorized, toggle the lock status of the event
-		await events.toggleLockById(request.params.id);
-		const foundEvent = await events.findById(request.params.id);
+		await goDB.offer.events.toggleLockById(request.params.id);
+		const foundEvent = await goDB.offer.events.findById(request.params.id);
 		if (!foundEvent) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Event not found');
 		}
@@ -299,7 +300,7 @@ export class EventsController {
 		//
 		// Get the Event from the database
 
-		const eventData = await events.findById(request.params.id);
+		const eventData = await goDB.offer.events.findById(request.params.id);
 
 		if (!eventData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Event not found');
@@ -335,7 +336,7 @@ export class EventsController {
 		//
 		// Update the event
 
-		const updatedEvent = await events.updateById(eventData._id, request.body);
+		const updatedEvent = await goDB.offer.events.updateById(eventData._id, request.body);
 
 		//
 		// Send the updated event data as the response

--- a/modules/offer/apps/api/src/utils/rules.ts
+++ b/modules/offer/apps/api/src/utils/rules.ts
@@ -1,5 +1,6 @@
 import { resolvePatternRules } from '@tmlmobilidade/dates';
-import { events, lines } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
+import { lines } from '@tmlmobilidade/interfaces';
 import { type Pattern } from '@tmlmobilidade/types';
 
 export async function mergePatternWithEventRules(pattern: Pattern): Promise<Pattern> {
@@ -7,7 +8,7 @@ export async function mergePatternWithEventRules(pattern: Pattern): Promise<Patt
 	if (!line) return pattern;
 
 	// Fetch all events for this agency - filtering happens at the rule level
-	const candidateEvents = await events.findMany({
+	const candidateEvents = await goDB.offer.events.findMany({
 		agency_ids: { $in: [line.agency_id] },
 	});
 

--- a/modules/offer/apps/gtfs-exporter/src/fetchers/events.ts
+++ b/modules/offer/apps/gtfs-exporter/src/fetchers/events.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { events } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { Event } from '@tmlmobilidade/types';
 
 /* * */
@@ -12,7 +12,7 @@ import { Event } from '@tmlmobilidade/types';
  */
 export async function fetchAllEvents(agencyIds: string[]): Promise<Map<string, Event>> {
 	try {
-		const allEvents = await events.findByAgencyIds(agencyIds);
+		const allEvents = await goDB.offer.events.findByAgencyIds(agencyIds);
 		const eventsMap = new Map<string, Event>();
 		for (const event of allEvents) {
 			eventsMap.set(event._id, event);

--- a/modules/offer/apps/gtfs-importer/src/fetchers/events.ts
+++ b/modules/offer/apps/gtfs-importer/src/fetchers/events.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import { events } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { Event } from '@tmlmobilidade/types';
 
 /* * */
@@ -12,7 +12,7 @@ import { Event } from '@tmlmobilidade/types';
  */
 export async function fetchAllEvents(agencyId: string): Promise<Map<string, Event>> {
 	try {
-		const allEvents = await events.findByAgencyIds([agencyId]);
+		const allEvents = await goDB.offer.events.findByAgencyIds([agencyId]);
 		const eventsMap = new Map<string, Event>();
 		for (const event of allEvents) {
 			eventsMap.set(event._id, event);


### PR DESCRIPTION
## Summary

Migrate event callers from importing `events` from `@tmlmobilidade/interfaces` to using `goDb.offer.events` so offer calendar data access is grouped under `goDb.offer`.

## Changes

- **events.controller.ts**: Replace `events` import with `goDb.offer.events`
- **offer rules.ts**: Update event access to use goDb namespace
- **gtfs-exporter fetchers/events.ts**: Migrate event fetcher to goDb
- **gtfs-importer fetchers/events.ts**: Migrate event fetcher to goDb

Closes https://linear.app/cmetropolitana/issue/GO-614/add-godbofferevents-access-to-event-callers