### PR TITLE
feat(typologies): migrate typology access to goDB interface

### DIFF
--- a/modules/offer/apps/api/src/endpoints/patterns/patterns.controller.ts
+++ b/modules/offer/apps/api/src/endpoints/patterns/patterns.controller.ts
@@ -6,7 +6,8 @@ import { createImportedStopResolver } from '@/utils/stops.js';
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
 import { encodePolylineFromGeoJson } from '@tmlmobilidade/geo';
-import { lines, patterns, stops, typologies } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
+import { lines, patterns, stops } from '@tmlmobilidade/interfaces';
 import { generateRandomString } from '@tmlmobilidade/strings';
 import { CreatePatternDto, NoteComment, type Pattern, type PatternShapeMapItem, PermissionCatalog, PopulatedPath, PopulatedPattern, StopsParameter, type UpdatePatternDto, UpdatePatternSchema } from '@tmlmobilidade/types';
 
@@ -126,7 +127,7 @@ export class PatternsController {
 		const lineIds = agencyLines.map(line => line._id);
 		if (!lineIds.length) return reply.send({ data: [], error: null, statusCode: HTTP_STATUS.OK });
 
-		const agencyTypologies = await typologies.findByAgencyIds(agencyIds);
+		const agencyTypologies = await goDB.offer.typologies.findByAgencyIds(agencyIds);
 		const typologyColorById = new Map(agencyTypologies.map(typology => [typology._id, typology.color]));
 		const typologyTextColorById = new Map(agencyTypologies.map(typology => [typology._id, typology.text_color]));
 		const lineById = new Map(agencyLines.map(line => [line._id, line]));

--- a/modules/offer/apps/api/src/endpoints/typologies/typologies.controller.ts
+++ b/modules/offer/apps/api/src/endpoints/typologies/typologies.controller.ts
@@ -2,7 +2,8 @@
 
 import { HTTP_STATUS, HttpException } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
-import { type Filter, typologies } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
+import { type Filter } from '@tmlmobilidade/interfaces';
 import { CreateTypologyDto, PermissionCatalog, type PermissionResourceCheck, type Typology, type UpdateTypologyDto } from '@tmlmobilidade/types';
 
 /* * */
@@ -56,7 +57,7 @@ export class TypologiesController {
 		//
 		// Create the new typology
 
-		const newTypology = await typologies.insertOne(request.body);
+		const newTypology = await goDB.offer.typologies.insertOne(request.body);
 
 		//
 		// Send the response
@@ -73,7 +74,7 @@ export class TypologiesController {
 	 */
 	static async delete(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<void>) {
 		const { id } = request.params;
-		const typology = await typologies.findById(id);
+		const typology = await goDB.offer.typologies.findById(id);
 
 		if (!typology) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Typology not found');
@@ -108,7 +109,7 @@ export class TypologiesController {
 
 		//
 
-		await typologies.deleteById(id);
+		await goDB.offer.typologies.deleteById(id);
 
 		reply.send({ data: undefined, error: null, statusCode: HTTP_STATUS.OK });
 	}
@@ -139,7 +140,7 @@ export class TypologiesController {
 		//
 		// Fetch typologies based on query filters
 
-		const allTypologies = await typologies.findMany(queryFilters, { sort: { created_at: -1 } });
+		const allTypologies = await goDB.offer.typologies.findMany(queryFilters, { sort: { created_at: -1 } });
 
 		return reply.send({ data: allTypologies, error: null, statusCode: HTTP_STATUS.OK });
 		//
@@ -156,7 +157,7 @@ export class TypologiesController {
 		//
 		// Get the Typology from the database
 
-		const typologyData = await typologies.findById(request.params.id);
+		const typologyData = await goDB.offer.typologies.findById(request.params.id);
 
 		if (!typologyData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Typology not found');
@@ -200,7 +201,7 @@ export class TypologiesController {
 		//
 		// Get the Typology from the database
 
-		const typologyData = await typologies.findById(request.params.id);
+		const typologyData = await goDB.offer.typologies.findById(request.params.id);
 
 		if (!typologyData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Typology not found');
@@ -234,8 +235,8 @@ export class TypologiesController {
 		}
 
 		// If authorized, toggle the lock status of the typology
-		await typologies.toggleLockById(request.params.id);
-		const foundTypology = await typologies.findById(request.params.id);
+		await goDB.offer.typologies.toggleLockById(request.params.id);
+		const foundTypology = await goDB.offer.typologies.findById(request.params.id);
 		if (!foundTypology) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Typology not found');
 		}
@@ -256,7 +257,7 @@ export class TypologiesController {
 		//
 		// Get the Typology from the database
 
-		const typologyData = await typologies.findById(request.params.id);
+		const typologyData = await goDB.offer.typologies.findById(request.params.id);
 
 		if (!typologyData) {
 			throw new HttpException(HTTP_STATUS.NOT_FOUND, 'Typology not found');
@@ -292,7 +293,7 @@ export class TypologiesController {
 		//
 		// Update the typology
 
-		const updatedTypology = await typologies.updateById(typologyData._id, request.body);
+		const updatedTypology = await goDB.offer.typologies.updateById(typologyData._id, request.body);
 
 		//
 		// Send the updated typology data as the response

--- a/modules/offer/apps/gtfs-exporter/src/fetchers/typology.ts
+++ b/modules/offer/apps/gtfs-exporter/src/fetchers/typology.ts
@@ -1,4 +1,4 @@
-import { typologies } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { Typology } from '@tmlmobilidade/types';
 
 /**
@@ -7,7 +7,7 @@ import { Typology } from '@tmlmobilidade/types';
  */
 export async function fetchAllTypologies(): Promise<Map<string, Typology>> {
 	try {
-		const allTypologies = await typologies.findMany({});
+		const allTypologies = await goDB.offer.typologies.findMany({});
 		const typologiesMap = new Map<string, Typology>();
 		for (const typology of allTypologies) {
 			typologiesMap.set(typology._id, typology);
@@ -38,7 +38,7 @@ export async function getTypologyDetails(
 
 	// Otherwise, fetch individually
 	try {
-		return await typologies.findById(typologyId);
+		return await goDB.offer.typologies.findById(typologyId);
 	}
 	catch (error) {
 		throw new Error(`Error fetching typology ${typologyId}: ${error}`);

--- a/modules/offer/apps/gtfs-importer/src/fetchers/typology.ts
+++ b/modules/offer/apps/gtfs-importer/src/fetchers/typology.ts
@@ -1,4 +1,4 @@
-import { typologies } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { Typology } from '@tmlmobilidade/types';
 
 /**
@@ -9,7 +9,7 @@ import { Typology } from '@tmlmobilidade/types';
 export async function fetchTypologiesByAgencyIds(agencyIds: string[]): Promise<Typology[]> {
 	try {
 		if (!agencyIds.length) return [];
-		return await typologies.findByAgencyIds(agencyIds);
+		return await goDB.offer.typologies.findByAgencyIds(agencyIds);
 	} catch (error) {
 		throw new Error(`Error fetching typologies by agency IDs: ${error}`);
 	}
@@ -34,7 +34,7 @@ export async function getTypologyDetails(
 
 	// Otherwise, fetch individually
 	try {
-		return await typologies.findById(typologyId);
+		return await goDB.offer.typologies.findById(typologyId);
 	} catch (error) {
 		throw new Error(`Error fetching typology ${typologyId}: ${error}`);
 	}

--- a/modules/offer/helpers/seed-typologies/src/index.ts
+++ b/modules/offer/helpers/seed-typologies/src/index.ts
@@ -1,7 +1,7 @@
 /* * */
 
 import { seedFromGoV1 } from '@/tasks/seed-from-go-v1.js';
-import { typologies } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 
 /* * */
 
@@ -12,7 +12,7 @@ import { typologies } from '@tmlmobilidade/interfaces';
 	// Delete existing typologies
 
 	console.log('Deleting All');
-	await typologies.deleteMany({});
+	await goDB.offer.typologies.deleteMany({});
 
 	//
 	// Run tasks

--- a/modules/offer/helpers/seed-typologies/src/tasks/seed-from-go-v1.ts
+++ b/modules/offer/helpers/seed-typologies/src/tasks/seed-from-go-v1.ts
@@ -2,7 +2,7 @@
 
 import { type OriginalTypologyType } from '@/original-typology.type.js';
 import { Dates } from '@tmlmobilidade/dates';
-import { typologies } from '@tmlmobilidade/interfaces';
+import { goDB } from '@tmlmobilidade/go-interfaces-go-db';
 import { generateRandomString } from '@tmlmobilidade/strings';
 import { type Typology, TypologySchema } from '@tmlmobilidade/types';
 
@@ -131,7 +131,7 @@ export async function seedFromGoV1() {
 		//
 		// Insert typologies into DB
 
-		await typologies.insertMany(preparedTypologies, { unsafe: true });
+		await goDB.offer.typologies.insertMany(preparedTypologies, { unsafe: true });
 		console.log(`Inserted ${preparedTypologies.length} typologies`);
 
 		//


### PR DESCRIPTION
## Summary

Migrate typology callers from `@tmlmobilidade/interfaces` to `goDb.offer.typologies`, putting typology reads and writes under the offer database namespace. End-user APIs are unchanged.

## Changes

- **Typology callers**: Migrate `typologies.controller.ts`, GTFS exporter/importer fetchers, seed-typologies helper, and patterns controller to `goDB.offer.typologies`
- **Interface packages**: Rename `godb` → `go-db`, `cachedb` → `cache-db`, `labdb` → `lab-db`, `rawdb` → `raw-db` for consistency
- **New interfaces**: Add auth (roles, sessions, users, verification-tokens), agencies, and organizations interfaces to common interfaces package
- **Cleanup**: Remove unused `pcgi-file-manager` interface, `auth` provider, `AppWrapperBanner` component, and `ReactModalSheet` component
- **Deps**: Update import paths across all modules for renamed packages

Closes GO-620