### PR TITLE
refactor(api): update type imports for network controllers

### DIFF
--- a/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-pattern.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-pattern.ts
@@ -3,7 +3,7 @@
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
 import { cacheDb } from '@tmlmobilidade/go-interfaces-cachedb';
-import { type HubLine } from '@tmlmobilidade/go-types-public-info';
+import { type HubPattern } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 
 /**
@@ -11,7 +11,7 @@ import { Logger } from '@tmlmobilidade/logger';
  * @param request The request object.
  * @param reply The reply object.
  */
-export async function getPattern(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<HubLine[]>) {
+export async function getPattern(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply<HubPattern[]>) {
 	//
 
 	const cachedData = await cacheDb.get(`hub:v1:network:patterns:${request.params.id}`);

--- a/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-routes.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-routes.ts
@@ -3,7 +3,7 @@
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
 import { cacheDb } from '@tmlmobilidade/go-interfaces-cachedb';
-import { type HubLine } from '@tmlmobilidade/go-types-public-info';
+import { type HubRoute } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 
 /**
@@ -11,7 +11,7 @@ import { Logger } from '@tmlmobilidade/logger';
  * @param request The request object.
  * @param reply The reply object.
  */
-export async function getRoutes(request: FastifyRequest, reply: FastifyReply<HubLine[]>) {
+export async function getRoutes(request: FastifyRequest, reply: FastifyReply<HubRoute[]>) {
 	//
 
 	const cachedData = await cacheDb.get('hub:v1:network:routes');

--- a/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-stops.ts
+++ b/modules/hub/apps/api/src/endpoints/v1/network/controllers/get-stops.ts
@@ -3,7 +3,7 @@
 import { HTTP_STATUS } from '@tmlmobilidade/consts';
 import { type FastifyReply, type FastifyRequest } from '@tmlmobilidade/fastify';
 import { cacheDb } from '@tmlmobilidade/go-interfaces-cachedb';
-import { type HubLine } from '@tmlmobilidade/go-types-public-info';
+import { HubStop } from '@tmlmobilidade/go-types-public-info';
 import { Logger } from '@tmlmobilidade/logger';
 
 /**
@@ -11,7 +11,7 @@ import { Logger } from '@tmlmobilidade/logger';
  * @param request The request object.
  * @param reply The reply object.
  */
-export async function getStops(request: FastifyRequest, reply: FastifyReply<HubLine[]>) {
+export async function getStops(request: FastifyRequest, reply: FastifyReply<HubStop[]>) {
 	//
 
 	const cachedData = await cacheDb.get('hub:v1:network:stops');


### PR DESCRIPTION
- Replaced `HubLine` with `HubPattern`, `HubRoute`, and `HubStop` in the `get-pattern`, `get-routes`, and `get-stops` controllers respectively to align with updated type definitions.
- This change enhances type accuracy and improves code maintainability across the network API endpoints.