### PR TITLE
fix(performance): support agency ID migration

### DIFF
--- a/modules/performance/apps/frontend/src/components/visualizations/RealtimeDemand/index.tsx
+++ b/modules/performance/apps/frontend/src/components/visualizations/RealtimeDemand/index.tsx
@@ -6,6 +6,7 @@ import { RecordDemand } from '@/components/visualizations/RecordDemand';
 import { AgencyType } from '@/constants';
 import { useHomeContext } from '@/contexts/Home.context';
 import { MetricsRoutes } from '@/routes';
+import { getMetricAgencyData } from '@/utils/agencies';
 import { IconUser } from '@tabler/icons-react';
 import { type RealtimeDemand } from '@tmlmobilidade/types';
 import { Spacer } from '@tmlmobilidade/ui';
@@ -46,10 +47,10 @@ export function RealtimeDemand({ agency }: { agency?: AgencyType }) {
 
 		const agenciesData = selectedAgency === 'all'
 			? latest.data.total
-			: latest.data.agencies[selectedAgency];
+			: getMetricAgencyData(latest.data.agencies, selectedAgency);
 
-		const now = agenciesData.now;
-		const lastWeek = agenciesData.last_week;
+		const now = agenciesData?.now ?? 0;
+		const lastWeek = agenciesData?.last_week ?? 0;
 		const progress = lastWeek > 0 ? (now / lastWeek) * 100 : 0;
 
 		return {

--- a/modules/performance/apps/frontend/src/components/visualizations/RecordDemandByDayType/index.tsx
+++ b/modules/performance/apps/frontend/src/components/visualizations/RecordDemandByDayType/index.tsx
@@ -8,6 +8,7 @@ import { AgencyType } from '@/constants';
 import { useAgenciesContext } from '@/contexts/Agencies.context';
 import { useDatesContext } from '@/contexts/Dates.context';
 import { Routes } from '@/routes';
+import { getMetricAgencyData } from '@/utils/agencies';
 import { TopDemandByAgencyByDayType } from '@tmlmobilidade/types';
 import { BarChart, Grid, MetricsSkeleton, Section, Skeleton, Surface } from '@tmlmobilidade/ui';
 import { useTranslations } from 'next-intl';
@@ -33,7 +34,7 @@ export default function RecordDemandByDayType() {
 	// C. Transform data
 
 	const transformedRecordData: Record<string, { date: string, qty: number }[]> = useMemo(() => {
-		if (!recordDemandByDayType) return {};
+		if (!recordDemandByDayType?.length) return {};
 
 		const data = recordDemandByDayType[0].data;
 
@@ -43,7 +44,7 @@ export default function RecordDemandByDayType() {
 		const agencyData = isAllSelected
 			? data.total
 			: selectedAgencies.length === 1
-				? data.agencies?.[selectedAgencies[0]]
+				? getMetricAgencyData(data.agencies, selectedAgencies[0])
 				: data.total; // Fallback to total for multiple specific agencies
 
 		if (!agencyData) return {};
@@ -105,10 +106,6 @@ export default function RecordDemandByDayType() {
 				</Section>
 			</Surface>
 		);
-	}
-
-	if (!transformedRecordData || Object.keys(transformedRecordData).length === 0) {
-		return null;
 	}
 
 	return (

--- a/modules/performance/apps/frontend/src/components/visualizations/ServiceCompliance/index.tsx
+++ b/modules/performance/apps/frontend/src/components/visualizations/ServiceCompliance/index.tsx
@@ -7,6 +7,7 @@ import { TrendChip } from '@/components/layout/TrendChip';
 import { AgencyType } from '@/constants';
 import { useHomeContext } from '@/contexts/Home.context';
 import { MetricsRoutes } from '@/routes';
+import { getMetricAgencyData } from '@/utils/agencies';
 import { IconBus } from '@tabler/icons-react';
 import { RealtimeServiceCompliance } from '@tmlmobilidade/types';
 import { Grid, SemiCircleProgress } from '@tmlmobilidade/ui';
@@ -51,7 +52,21 @@ export function ServiceCompliance({ agency }: { agency?: AgencyType }) {
 
 		const agencyData = selectedAgency === 'all'
 			? latest.data.total
-			: latest.data.agencies[selectedAgency];
+			: getMetricAgencyData(latest.data.agencies, selectedAgency);
+
+		if (!agencyData) {
+			return {
+				accomplishedRides: { last_week: 0, now: 0 },
+				advancedRides: { last_week: 0, now: 0 },
+				delayedRides: { last_week: 0, now: 0 },
+				lastUpdated: new Date(latest.generated_at),
+				noPassengerRides: { last_week: 0, now: 0 },
+				ridesWithSales: { last_week: 0, now: 0 },
+				scheduledRides: { last_week: 0, now: 0 },
+				validRides: { last_week: 0, now: 0 },
+				validRidesPct: 0,
+			};
+		}
 
 		const calculatePct = (part: number, total: number) => {
 			return total > 0 ? (part / total) * 100 : 0;

--- a/modules/performance/apps/frontend/src/constants.ts
+++ b/modules/performance/apps/frontend/src/constants.ts
@@ -167,10 +167,28 @@ export const TOPICS_REGISTRY: TopicDefinition[] = [
 ];
 
 export const AGENCIES = {
-	AREA_1: '41',
-	AREA_2: '42',
-	AREA_3: '43',
-	AREA_4: '44',
+	AREA_1: 'LA77N',
+	AREA_2: 'BNA17',
+	AREA_3: 'YA15B',
+	AREA_4: 'A2L1N',
+} as const;
+
+export const AGENCY_IDS_BY_AREA = [
+	AGENCIES.AREA_1,
+	AGENCIES.AREA_2,
+	AGENCIES.AREA_3,
+	AGENCIES.AREA_4,
+] as const;
+
+export const AGENCY_ID_EQUIVALENTS = {
+	41: ['41', 'LA77N'],
+	42: ['42', 'BNA17'],
+	43: ['43', 'YA15B'],
+	44: ['44', 'A2L1N'],
+	A2L1N: ['A2L1N', '44'],
+	BNA17: ['BNA17', '42'],
+	LA77N: ['LA77N', '41'],
+	YA15B: ['YA15B', '43'],
 } as const;
 
 export type AgencyType = typeof AGENCIES[keyof typeof AGENCIES];

--- a/modules/performance/apps/frontend/src/contexts/Agencies.context.tsx
+++ b/modules/performance/apps/frontend/src/contexts/Agencies.context.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { AGENCIES, type AgencyType } from '@/constants';
+import { AGENCY_IDS_BY_AREA, type AgencyType } from '@/constants';
 import { MetricsRoutes } from '@/routes';
+import { getMetricAgencyData } from '@/utils/agencies';
 import { calculateSystemHealthIndex, getSystemStatusInfo, type StatusInfo } from '@/utils/systemStatus';
 import { API_ROUTES } from '@tmlmobilidade/consts';
 import { type Agency as APIAgency, type RealtimeDemand, type RealtimeServiceCompliance } from '@tmlmobilidade/types';
@@ -32,6 +33,7 @@ interface AgenciesContextState {
 /* * */
 
 const AgenciesContext = createContext<AgenciesContextState | undefined>(undefined);
+const TARGET_AGENCIES = [...AGENCY_IDS_BY_AREA, 'all'] as const;
 
 export const useAgenciesContext = () => {
 	const context = useContext(AgenciesContext);
@@ -51,7 +53,6 @@ export const AgenciesContextProvider = ({ children }: PropsWithChildren) => {
 
 	const t = useTranslations();
 	const [systemStatuses, setSystemStatuses] = useState<Record<string, StatusInfo>>({});
-	const targetAgencies = [AGENCIES.AREA_1, AGENCIES.AREA_2, AGENCIES.AREA_3, AGENCIES.AREA_4, 'all'] as const;
 
 	//
 	// B. Fetch data
@@ -71,12 +72,12 @@ export const AgenciesContextProvider = ({ children }: PropsWithChildren) => {
 		const serviceDataObj = serviceComplianceData[0].data;
 		const demandDataObj = demandData[0].data;
 
-		targetAgencies.forEach((agency) => {
+		TARGET_AGENCIES.forEach((agency) => {
 			// Merge metrics
 			const metricsData: Record<string, { last_week: number, now: number }> = {};
 
-			const serviceData = agency === 'all' ? serviceDataObj.total : serviceDataObj.agencies?.[agency];
-			const demandMetric = agency === 'all' ? demandDataObj.total : demandDataObj.agencies?.[agency];
+			const serviceData = agency === 'all' ? serviceDataObj.total : getMetricAgencyData(serviceDataObj.agencies, agency);
+			const demandMetric = agency === 'all' ? demandDataObj.total : getMetricAgencyData(demandDataObj.agencies, agency);
 
 			if (!serviceData || !demandMetric) return;
 
@@ -111,13 +112,14 @@ export const AgenciesContextProvider = ({ children }: PropsWithChildren) => {
 		if (!allAgenciesData) return [];
 
 		return allAgenciesData
-			.filter(agency => targetAgencies.includes(agency._id as AgencyType))
+			.filter(agency => AGENCY_IDS_BY_AREA.includes(agency._id as AgencyType))
 			.map(agency => ({
 				...agency,
 				id: agency._id as AgencyType,
 				label: t(`agencies.${agency._id}`),
-			}));
-	}, [allAgenciesData, t, targetAgencies]);
+			}))
+			.sort((a, b) => AGENCY_IDS_BY_AREA.indexOf(a.id) - AGENCY_IDS_BY_AREA.indexOf(b.id));
+	}, [allAgenciesData, t]);
 
 	//
 	// E. Process agencies with "all" option
@@ -133,7 +135,7 @@ export const AgenciesContextProvider = ({ children }: PropsWithChildren) => {
 		if (systemStatuses['all']) {
 			result.push({
 				id: 'all' as AgencyType,
-				label: t('default:agencies.all'),
+				label: t('agencies.all'),
 			} as Agency);
 		}
 

--- a/modules/performance/apps/frontend/src/i18n/translations/pt.json
+++ b/modules/performance/apps/frontend/src/i18n/translations/pt.json
@@ -4,6 +4,10 @@
 		"42": "Área 2",
 		"43": "Área 3",
 		"44": "Área 4",
+		"A2L1N": "Área 4",
+		"BNA17": "Área 2",
+		"LA77N": "Área 1",
+		"YA15B": "Área 3",
 		"all": "Toda a CM"
 	},
 	"chart": {

--- a/modules/performance/apps/frontend/src/utils/agencies.ts
+++ b/modules/performance/apps/frontend/src/utils/agencies.ts
@@ -1,0 +1,21 @@
+/* * */
+
+import { AGENCY_ID_EQUIVALENTS } from '@/constants';
+
+/* * */
+
+export function getEquivalentAgencyIds(agencyId: string): readonly string[] {
+	if (agencyId in AGENCY_ID_EQUIVALENTS) {
+		return AGENCY_ID_EQUIVALENTS[agencyId as keyof typeof AGENCY_ID_EQUIVALENTS];
+	}
+
+	return [agencyId];
+}
+
+export function getMetricAgencyData<T>(agencies: Record<string, T>, agencyId: string): T | undefined {
+	for (const equivalentAgencyId of getEquivalentAgencyIds(agencyId)) {
+		if (equivalentAgencyId in agencies) return agencies[equivalentAgencyId];
+	}
+
+	return undefined;
+}

--- a/modules/performance/apps/frontend/src/utils/metrics/handlers/ChartTransformers/index.ts
+++ b/modules/performance/apps/frontend/src/utils/metrics/handlers/ChartTransformers/index.ts
@@ -2,6 +2,8 @@
 
 import type { MetricTransformOptions, RawMetricData, TransformResult } from '../../types';
 
+import { getEquivalentAgencyIds } from '@/utils/agencies';
+
 import { getLatestTimestamp } from '../../utils';
 import { transformToProgressBar } from './barProgressTransformer';
 import { transformToPie } from './pieTransformer';
@@ -18,6 +20,8 @@ export function filterDataByAgencies(data: RawMetricData[], agencyIds?: string[]
 		return data;
 	}
 
+	const equivalentAgencyIds = new Set(agencyIds.flatMap(agencyId => getEquivalentAgencyIds(agencyId)));
+
 	return data.filter((item) => {
 		// Check if the item has agency information in properties
 		const agencyId = item.properties?.agency_id || item.properties?.operator_id;
@@ -28,7 +32,7 @@ export function filterDataByAgencies(data: RawMetricData[], agencyIds?: string[]
 		}
 
 		// Include only items that match the specified agency IDs
-		return agencyIds.includes(agencyId);
+		return equivalentAgencyIds.has(agencyId);
 	});
 }
 

--- a/modules/performance/apps/sync-metrics-daily/src/constants.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/constants.ts
@@ -1,0 +1,4 @@
+/* * */
+
+export const GO_CM_AGENCY_IDS = ['LA77N', 'BNA17', 'YA15B', 'A2L1N'] as const;
+export const LEGACY_CM_AGENCY_IDS = ['41', '42', '43', '44'] as const;

--- a/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_category/by_agency_by_day.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_category/by_agency_by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
 import { metrics, simplifiedApexValidations } from '@tmlmobilidade/interfaces';
@@ -102,6 +103,7 @@ export const syncDemandByCategoryByAgencyByDay = async () => {
 				const validationsAgg = await validationsCollection.aggregate([
 					{
 						$match: {
+							agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 							created_at: { $gte: chunkData.start, $lt: chunkData.end },
 							is_passenger: true,
 						},

--- a/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_category/by_line_by_day.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_category/by_line_by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
 import { metrics, simplifiedApexValidations } from '@tmlmobilidade/interfaces';
@@ -102,6 +103,7 @@ export const syncDemandByCategoryByLineByDay = async () => {
 				const validationsAgg = await validationsCollection.aggregate([
 					{
 						$match: {
+							agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 							created_at: { $gte: chunkData.start, $lt: chunkData.end },
 							is_passenger: true,
 						},

--- a/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_category/by_pattern_by_day.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_category/by_pattern_by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
 import { metrics, simplifiedApexValidations } from '@tmlmobilidade/interfaces';
@@ -102,6 +103,7 @@ export const syncDemandByCategoryByPatternByDay = async () => {
 				const validationsAgg = await validationsCollection.aggregate([
 					{
 						$match: {
+							agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 							created_at: { $gte: chunkData.start, $lt: chunkData.end },
 							is_passenger: true,
 						},

--- a/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_pattern_hour/by_day.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_pattern_hour/by_day.ts
@@ -1,3 +1,4 @@
+import { GO_CM_AGENCY_IDS } from '@/constants.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { goDb } from '@tmlmobilidade/go-interfaces-godb';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
@@ -99,6 +100,7 @@ export const syncDemandByPatternHourByDay = async () => {
 					.aggregate([
 						{
 							$match: {
+								agency_id: { $in: [...GO_CM_AGENCY_IDS] },
 								passengers_observed: { $gt: 0 },
 								start_time_scheduled: {
 									$gte: chunkData.start,

--- a/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_product/by_agency_by_day.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_product/by_agency_by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
 import { metrics, simplifiedApexValidations } from '@tmlmobilidade/interfaces';
@@ -102,6 +103,7 @@ export const syncDemandByProductByAgencyByDay = async () => {
 				const validationsAgg = await validationsCollection.aggregate([
 					{
 						$match: {
+							agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 							created_at: { $gte: chunkData.start, $lt: chunkData.end },
 							is_passenger: true,
 						},

--- a/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_product/by_line_by_day.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_product/by_line_by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
 import { metrics, simplifiedApexValidations } from '@tmlmobilidade/interfaces';
@@ -102,6 +103,7 @@ export const syncDemandByProductByLineByDay = async () => {
 				const validationsAgg = await validationsCollection.aggregate([
 					{
 						$match: {
+							agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 							created_at: { $gte: chunkData.start, $lt: chunkData.end },
 							is_passenger: true,
 						},

--- a/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_product/by_pattern_by_day.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/syncs/demand_by_product/by_pattern_by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
 import { metrics, simplifiedApexValidations } from '@tmlmobilidade/interfaces';
@@ -102,6 +103,7 @@ export const syncDemandByProductByPatternByDay = async () => {
 				const validationsAgg = await validationsCollection.aggregate([
 					{
 						$match: {
+							agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 							created_at: { $gte: chunkData.start, $lt: chunkData.end },
 							is_passenger: true,
 						},

--- a/modules/performance/apps/sync-metrics-daily/src/syncs/passenger-impact/passenger-impact_by_day.ts
+++ b/modules/performance/apps/sync-metrics-daily/src/syncs/passenger-impact/passenger-impact_by_day.ts
@@ -1,3 +1,4 @@
+import { GO_CM_AGENCY_IDS } from '@/constants.js';
 import { Dates } from '@tmlmobilidade/dates';
 import { goDb } from '@tmlmobilidade/go-interfaces-godb';
 import { AggregationPipeline, metrics } from '@tmlmobilidade/interfaces';
@@ -34,8 +35,6 @@ function median(values: number[]): number {
 export async function syncPassengerImpactServiceFailuresByDay(): Promise<
 	Map<OperationalDate, Map<AgencyId, AgencyDayStats>>
 > {
-	const agencyFilter: AgencyId[] = ['41', '42', '43', '44'];
-
 	// Target interval (operational cut-off at 04:00)
 	const startDate = Dates.now('Europe/Lisbon')
 		.set({ day: 1, hour: 4, month: 1, year: 2024 })
@@ -56,7 +55,7 @@ export async function syncPassengerImpactServiceFailuresByDay(): Promise<
 	const ridesPipeline: AggregationPipeline<Ride> = [
 		{
 			$match: {
-				'agency_id': { $in: agencyFilter },
+				'agency_id': { $in: [...GO_CM_AGENCY_IDS] },
 				'analysis.SIMPLE_ONE_APEX_VALIDATION.grade': 'fail',
 				'analysis.SIMPLE_THREE_VEHICLE_EVENTS.grade': 'fail',
 				'start_time_scheduled': { $gte: startDate, $lt: endDate },
@@ -144,7 +143,7 @@ export async function syncPassengerImpactServiceFailuresByDay(): Promise<
 		const passengersPipeline: AggregationPipeline<Ride> = [
 			{
 				$match: {
-					agency_id: { $in: agencyFilter },
+					agency_id: { $in: [...GO_CM_AGENCY_IDS] },
 					passengers_observed: { $ne: null },
 					start_time_scheduled: { $gte: start30dTs, $lt: endTs },
 				},

--- a/modules/performance/apps/sync-metrics-hourly/src/constants.ts
+++ b/modules/performance/apps/sync-metrics-hourly/src/constants.ts
@@ -1,0 +1,4 @@
+/* * */
+
+export const GO_CM_AGENCY_IDS = ['LA77N', 'BNA17', 'YA15B', 'A2L1N'] as const;
+export const LEGACY_CM_AGENCY_IDS = ['41', '42', '43', '44'] as const;

--- a/modules/performance/apps/sync-metrics-hourly/src/syncs/demand_by_agency/by_day.ts
+++ b/modules/performance/apps/sync-metrics-hourly/src/syncs/demand_by_agency/by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { dayLabelFromStartIso } from '@/utils/day-label.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
@@ -97,6 +98,7 @@ export const syncDemandByAgencyByDay = async () => {
 			const validationsAgg = await validationsCollection.aggregate([
 				{
 					$match: {
+						agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 						created_at: { $gte: chunkData.start, $lt: chunkData.end },
 						is_passenger: true,
 					},

--- a/modules/performance/apps/sync-metrics-hourly/src/syncs/demand_by_line/by_day.ts
+++ b/modules/performance/apps/sync-metrics-hourly/src/syncs/demand_by_line/by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { dayLabelFromStartIso } from '@/utils/day-label.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
@@ -97,6 +98,7 @@ export const syncDemandByLineByDay = async () => {
 			const validationsAgg = await validationsCollection.aggregate([
 				{
 					$match: {
+						agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 						created_at: { $gte: chunkData.start, $lt: chunkData.end },
 						is_passenger: true,
 					},

--- a/modules/performance/apps/sync-metrics-hourly/src/syncs/demand_by_pattern/by_day.ts
+++ b/modules/performance/apps/sync-metrics-hourly/src/syncs/demand_by_pattern/by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { dayLabelFromStartIso } from '@/utils/day-label.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
@@ -92,6 +93,7 @@ export const syncDemandByPatternByDay = async () => {
 			const validationsAgg = await validationsCollection.aggregate([
 				{
 					$match: {
+						agency_id: { $in: [...LEGACY_CM_AGENCY_IDS] },
 						created_at: { $gte: chunkData.start, $lt: chunkData.end },
 						is_passenger: true,
 					},

--- a/modules/performance/apps/sync-metrics-hourly/src/syncs/supply_by_agency/by_day.ts
+++ b/modules/performance/apps/sync-metrics-hourly/src/syncs/supply_by_agency/by_day.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { GO_CM_AGENCY_IDS } from '@/constants.js';
 import { dayLabelFromOperationalDate } from '@/utils/day-label.js';
 import { type CalendarEntry, Dates } from '@tmlmobilidade/dates';
 import { goDb } from '@tmlmobilidade/go-interfaces-godb';
@@ -13,8 +14,7 @@ import pLimit from 'p-limit';
 /* * */
 
 /** CM (Carris Metropolitana) agency areas — temporary scope filter */
-const CM_AGENCY_IDS = ['41', '42', '43', '44'] as const;
-const CM_AGENCY_ID_SET = new Set<string>(CM_AGENCY_IDS);
+const GO_CM_AGENCY_ID_SET = new Set<string>(GO_CM_AGENCY_IDS);
 
 /* * */
 
@@ -30,7 +30,7 @@ export const syncSupplyByAgencyByDay = async () => {
 	Logger.info({ message: `Clearing existing '${metricKey}' metrics for CM agencies...` });
 	await metrics.deleteMany({
 		'metric': metricKey,
-		'properties.agency_id': { $in: [...CM_AGENCY_IDS] },
+		'properties.agency_id': { $in: [...GO_CM_AGENCY_IDS] },
 	});
 	Logger.info({ message: `Cleared existing metrics in ${deleteTimer.get()}` });
 
@@ -48,7 +48,7 @@ export const syncSupplyByAgencyByDay = async () => {
 
 	const agenciesDocs = await agenciesCollection
 		.find(
-			{ _id: { $in: [...CM_AGENCY_IDS] } },
+			{ _id: { $in: [...GO_CM_AGENCY_IDS] } },
 			{
 				projection: {
 					'_id': 1,
@@ -97,7 +97,7 @@ export const syncSupplyByAgencyByDay = async () => {
 
 	const latestRide = await ridesCollection.findOne(
 		{
-			agency_id: { $in: [...CM_AGENCY_IDS] },
+			agency_id: { $in: [...GO_CM_AGENCY_IDS] },
 			operational_date: { $exists: true, $ne: null },
 		},
 		{ projection: { operational_date: 1 }, sort: { operational_date: -1 } },
@@ -131,7 +131,7 @@ export const syncSupplyByAgencyByDay = async () => {
 	Logger.info({ message: [
 		`Date range: ${earliestDataNeeded.operational_date} → ${latestOperationalData ?? 'today'}`,
 		`Total chunks: ${allTimestampChunks.length}`,
-		`CM agencies: ${CM_AGENCY_IDS.join(', ')}`,
+		`CM agencies: ${GO_CM_AGENCY_IDS.join(', ')}`,
 	] });
 
 	//
@@ -157,7 +157,7 @@ export const syncSupplyByAgencyByDay = async () => {
 					.aggregate([
 						{
 							$match: {
-								agency_id: { $in: [...CM_AGENCY_IDS] },
+								agency_id: { $in: [...GO_CM_AGENCY_IDS] },
 								operational_date: chunkData.operationalDate,
 							},
 						},
@@ -246,7 +246,7 @@ export const syncSupplyByAgencyByDay = async () => {
 		for (const agencyStats of ridesAgg) {
 			const agencyId = String(agencyStats._id ?? 'no-agency');
 
-			if (!CM_AGENCY_ID_SET.has(agencyId)) {
+			if (!GO_CM_AGENCY_ID_SET.has(agencyId)) {
 				continue;
 			}
 

--- a/modules/performance/apps/sync-metrics-realtime/src/constants.ts
+++ b/modules/performance/apps/sync-metrics-realtime/src/constants.ts
@@ -1,0 +1,4 @@
+/* * */
+
+export const GO_CM_AGENCY_IDS = ['LA77N', 'BNA17', 'YA15B', 'A2L1N'] as const;
+export const LEGACY_CM_AGENCY_IDS = ['41', '42', '43', '44'] as const;

--- a/modules/performance/apps/sync-metrics-realtime/src/tasks/sync-realtime-demand.ts
+++ b/modules/performance/apps/sync-metrics-realtime/src/tasks/sync-realtime-demand.ts
@@ -1,5 +1,6 @@
 /* * */
 
+import { LEGACY_CM_AGENCY_IDS } from '@/constants.js';
 import { Dates } from '@tmlmobilidade/dates';
 import { logMetricToFile } from '@tmlmobilidade/go-performance-pckg-log';
 import { metrics, simplifiedApexValidations } from '@tmlmobilidade/interfaces';
@@ -64,7 +65,6 @@ export const syncRealtimeDemand = async () => {
 	//
 	// Define agencies
 
-	const agency_ids = ['41', '42', '43', '44'];
 	const results: RealtimeDemand['data'] = {
 		agencies: {},
 		total: {
@@ -76,7 +76,7 @@ export const syncRealtimeDemand = async () => {
 	//
 	// Count validations per agency
 
-	for (const agencyId of agency_ids) {
+	for (const agencyId of LEGACY_CM_AGENCY_IDS) {
 		const agencyTimer = new Timer();
 		Logger.info({ message: `Processing Agency ${agencyId}...` });
 

--- a/modules/performance/apps/sync-metrics-realtime/src/tasks/sync-service-compliance.ts
+++ b/modules/performance/apps/sync-metrics-realtime/src/tasks/sync-service-compliance.ts
@@ -1,3 +1,4 @@
+import { GO_CM_AGENCY_IDS } from '@/constants.js';
 import { Dates } from '@tmlmobilidade/dates';
 import { goDb } from '@tmlmobilidade/go-interfaces-godb';
 import { metrics } from '@tmlmobilidade/interfaces';
@@ -128,8 +129,6 @@ export const syncRealtimeServiceCompliance = async () => {
 	//
 	// Initialize results object
 
-	const agencies = ['41', '42', '43', '44'];
-
 	const results: RealtimeServiceCompliance['data'] = {
 		agencies: {},
 		total: {
@@ -144,7 +143,7 @@ export const syncRealtimeServiceCompliance = async () => {
 		},
 	};
 
-	agencies.forEach((op) => {
+	GO_CM_AGENCY_IDS.forEach((op) => {
 		results.agencies[op] = {
 			accomplished_rides: { last_week: 0, now: 0 },
 			advanced_rides: { last_week: 0, now: 0 },
@@ -169,10 +168,14 @@ export const syncRealtimeServiceCompliance = async () => {
 	const todayTimer = new Timer();
 
 	const todayStream = ridesCollection
-		.find({ operational_date: currentOperationalDate, system_status: 'complete' })
+		.find({
+			agency_id: { $in: [...GO_CM_AGENCY_IDS] },
+			operational_date: currentOperationalDate,
+			system_status: 'complete',
+		})
 		.stream();
 
-	await processRidesStream(todayStream, results, agencies, 'now');
+	await processRidesStream(todayStream, results, [...GO_CM_AGENCY_IDS], 'now');
 	Logger.info({ message: `Processed today's rides in ${todayTimer.get()}` });
 
 	//
@@ -182,18 +185,19 @@ export const syncRealtimeServiceCompliance = async () => {
 	const lastWeekTimer = new Timer();
 
 	const lastWeekStream = ridesCollection.find({
+		agency_id: { $in: [...GO_CM_AGENCY_IDS] },
 		operational_date: previousOperationalDate,
 		start_time_observed: { $lte: previousUntilNowAsUnix },
 		system_status: 'complete',
 	}).stream();
 
-	await processRidesStream(lastWeekStream, results, agencies, 'last_week');
+	await processRidesStream(lastWeekStream, results, [...GO_CM_AGENCY_IDS], 'last_week');
 	Logger.info({ message: `Processed last week's rides in ${lastWeekTimer.get()}` });
 
 	//
 	// Compute mean delays
 
-	agencies.forEach((op) => {
+	GO_CM_AGENCY_IDS.forEach((op) => {
 		const opData = results.agencies[op];
 		opData.mean_delay_minutes.now = opData.scheduled_rides.now ? Number((opData.mean_delay_minutes.now / opData.scheduled_rides.now).toFixed(2)) : 0;
 		opData.mean_delay_minutes.last_week = opData.scheduled_rides.last_week ? Number((opData.mean_delay_minutes.last_week / opData.scheduled_rides.last_week).toFixed(2)) : 0;

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"dev:locations": "npm run repo:load-env-stg -- turbo run dev --filter=@tmlmobilidade/go-locations-*",
 		"dev:offer": "npm run repo:load-env-stg -- turbo run dev --filter=@tmlmobilidade/go-offer-api --filter=@tmlmobilidade/go-offer-frontend",
 		"dev:offer:gtfs-exporter": "npm run repo:load-env-stg -- turbo run dev --filter=@tmlmobilidade/go-offer-gtfs-exporter",
-		"dev:performance": "npm run build:performance && npm run repo:load-env-stg -- turbo run dev --filter=@tmlmobilidade/go-performance-*",
+		"dev:performance": "npm run build:performance && npm run repo:load-env-stg -- turbo run dev --filter=@tmlmobilidade/go-performance-frontend --filter=@tmlmobilidade/go-performance-api",
 		"dev:performance:sync-metrics-daily": "npm run build:performance:sync-metrics-daily && npm run repo:load-env-stg -- turbo run dev --filter=@tmlmobilidade/go-performance-sync-metrics-daily",
 		"dev:performance:sync-metrics-realtime": "npm run build:performance:sync-metrics-realtime && npm run repo:load-env-stg -- turbo run dev --filter=@tmlmobilidade/go-performance-sync-metrics-realtime",
 		"dev:plans": "npm run repo:load-env-stg -- turbo run dev --filter=@tmlmobilidade/go-plans-*",


### PR DESCRIPTION
Use legacy agency IDs for APEX validation metrics and new GO IDs for ride-based metrics. Add frontend aliases, stable area ordering, and preserve metric containers when filtered data is empty.