### PR TITLE
fix(workflows): remove auth module auto build for preview environments

### DIFF
--- a/.github/workflows/_preview-health.yml
+++ b/.github/workflows/_preview-health.yml
@@ -117,6 +117,7 @@ jobs:
                   '### Preview environment failed',
                   '',
                   `Creation of preview environment failed within ${timeout} minutes`,
+                  'Please try to build the auth module first if you didn\'t do it yet and then try again.',
                 ].join('\n');
 
             await github.rest.issues.createComment({

--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -102,14 +102,6 @@ jobs:
               return;
             }
 
-            // Preview enviroments need auth module always.
-            if (!buildAll) {
-              const hasAuth = modules.some((name) => name.toLowerCase() === 'auth');
-              if (!hasAuth) {
-                modules = ['auth', ...modules];
-              }
-            }
-
             core.info(`Dispatching build-modules for ${modules.join(', ')} on ref ${pr.head.ref}`);
             let runUrl = '';
             try {

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -47,7 +47,7 @@ jobs:
               '**Available modules:**',
               moduleList,
               '',
-              'Note: Auth module is building automatically when building other modules.'
+              'Note: You need to build auth module first for preview environment to work.'
             ].join('\n');
 
             github.rest.issues.createComment({


### PR DESCRIPTION
* Updated comments and messages in workflow files to emphasize the necessity of building the auth module before creating preview environments.
* Removed redundant checks for the auth module in the build command workflow to streamline the process.